### PR TITLE
10.1.0 created error catch

### DIFF
--- a/fyodor/src/main/java/life/genny/fyodor/utils/FyodorSearch.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/FyodorSearch.java
@@ -129,7 +129,12 @@ public class FyodorSearch {
 
 					// Filter unwanted attributes
 					if (columnWildcard == null) {
-						be = beUtils.addNonLiteralAttributes(be);
+						try {
+							be = beUtils.addNonLiteralAttributes(be);
+						} catch (Exception e) {
+							log.info("Stacktrace caught, printing but not failing...")
+							e.printStackTrace();
+						}
 						be = beUtils.privacyFilter(be, allowed);
 					}
 
@@ -608,7 +613,12 @@ public class FyodorSearch {
 
 					BaseEntity be = entities.get(i);
 
-					be = beUtils.addNonLiteralAttributes(be);
+					try {
+						be = beUtils.addNonLiteralAttributes(be);
+					} catch (Exception e) {
+						log.info("Stacktrace caught, printing but not failing...")
+						e.printStackTrace();
+					}
 					if (!columnWildcard) {
 						be = beUtils.privacyFilter(be, allowed);
 					}

--- a/fyodor/src/main/java/life/genny/fyodor/utils/FyodorSearch.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/FyodorSearch.java
@@ -132,7 +132,7 @@ public class FyodorSearch {
 						try {
 							be = beUtils.addNonLiteralAttributes(be);
 						} catch (Exception e) {
-							log.info("Stacktrace caught, printing but not failing...")
+							log.info("Stacktrace caught, printing but not failing...");
 							e.printStackTrace();
 						}
 						be = beUtils.privacyFilter(be, allowed);
@@ -616,7 +616,7 @@ public class FyodorSearch {
 					try {
 						be = beUtils.addNonLiteralAttributes(be);
 					} catch (Exception e) {
-						log.info("Stacktrace caught, printing but not failing...")
+						log.info("Stacktrace caught, printing but not failing...");
 						e.printStackTrace();
 					}
 					if (!columnWildcard) {


### PR DESCRIPTION
Surround the method with a try catch to prevent the process from failing when it comes across an entity with a null created field.