### PR TITLE
10.1.0 adi updates

### DIFF
--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/utils/KogitoUtils.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/utils/KogitoUtils.java
@@ -301,22 +301,8 @@ public class KogitoUtils {
 	 * @param data The stringified data message
 	 * @return A list of answers output from the inference rules
 	 */
-	public List<Answer> runDataInference(String data) {
+	public List<Answer> runDataInference(QDataAnswerMessage msg) {
 
-		// check if event is a valid event
-		QDataAnswerMessage msg = null;
-		try {
-			msg = jsonb.fromJson(data, QDataAnswerMessage.class);
-		} catch (Exception e) {
-			log.error("Cannot parse this data!");
-			e.printStackTrace();
-			return new ArrayList<>();
-		}
-
-		if (msg.getItems().length == 0) {
-			log.debug("Received empty answer message: " + data);
-			return new ArrayList<>();
-		}
 
 		// start new session
 		KieSession session = kieRuntimeBuilder.newKieSession();

--- a/qwandaq/src/main/java/life/genny/qwandaq/CoreEntity.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/CoreEntity.java
@@ -191,6 +191,8 @@ public abstract class CoreEntity implements CoreEntityInterface, CreatedIntf, Co
 	@XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
 	@JsonbTransient
 	public LocalDateTime getCreated() {
+		if(created == null)
+			autocreateCreated();
 		return created;
 	}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/exception/GennyExceptionIntf.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/exception/GennyExceptionIntf.java
@@ -3,7 +3,6 @@ package life.genny.qwandaq.exception;
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 
@@ -28,7 +27,7 @@ public interface GennyExceptionIntf {
 
         log.error("[!] " + throwable.getMessage());
         if (verbose) {
-            throwable.printStackTrace();
+            throwable.printStackTrace(System.err);
             return;
         }
 

--- a/serviceq/src/main/java/life/genny/serviceq/intf/GennyScopeInit.java
+++ b/serviceq/src/main/java/life/genny/serviceq/intf/GennyScopeInit.java
@@ -2,6 +2,11 @@ package life.genny.serviceq.intf;
 
 import io.quarkus.arc.Arc;
 
+import java.time.Duration;
+import java.time.Instant;
+
+import static life.genny.qwandaq.utils.SecurityUtils.obfuscate;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.json.JsonObject;
@@ -21,7 +26,7 @@ public class GennyScopeInit {
 	static final Logger log = Logger.getLogger(GennyScopeInit.class);
 
 	Jsonb jsonb = JsonbBuilder.create();
-
+	Instant start, end;
 	@Inject
 	UserToken userToken;
 
@@ -36,7 +41,9 @@ public class GennyScopeInit {
 	 *
 	 * @param data The consumed message from kafka
 	 **/
-	public void init(String data) { 
+	public void init(String data, Instant start) { 
+		this.start = start;
+		log.info("Received Data : " + obfuscate(data));
 
 		// activate request scope and fetch UserToken
 		Arc.container().requestContext().activate();
@@ -61,10 +68,17 @@ public class GennyScopeInit {
 		}
     }
 
+	public void init(String data) {
+		init(data, Instant.now());
+	}
+
 	/**
 	 * Destroy the UserToken using the request context.
 	 **/
 	public void destroy() { 
 		Arc.container().requestContext().activate();
+		// log duration
+		Instant end = Instant.now();
+		log.info("Duration = " + Duration.between(start, end).toMillis() + "ms");
 	}
 }


### PR DESCRIPTION
Moved Instant timing to GennyScopeInit. Removed kogitoUtils.funnelAnswers in gadaq (this call is meant to be at the end of the ADI pipeline, in prd_internmatch and prd_lojing. Can abstract this further for the products if necessary). Updated logging in gadaq/InternalConsumer:valid_data consumer