### PR TITLE
Got cancelling working in processQuestions

### DIFF
--- a/b.sh
+++ b/b.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+mvn clean
 cd qwandaq;./build.sh;cd ../serviceq;./build.sh;cd kogitoq/kogito-common;./build.sh;cd ../gadaq;./build.sh;./build-docker.sh;cd ../bridge;./build.sh;./build-docker.sh;cd ../lauchy;./build.sh;./build-docker.sh;cd ../dropkick;./build.sh;./build-docker.sh;cd ../fyodor;./build.sh;./build-docker.sh;cd ..

--- a/bridge/build-docker.sh
+++ b/bridge/build-docker.sh
@@ -17,6 +17,7 @@ echo "project = ${project}"
 echo "org= ${org}"
 echo "version = ${version}"
 USER=`whoami`
+mvn clean
 ./mvnw clean package -Dquarkus.container-image.build=true -DskipTests=true
 docker tag ${org}/${project}:${version} ${org}/${project}:${version}
 docker tag ${org}/${project}:${version} ${org}/${project}:latest

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -15,6 +15,10 @@
 
 	<name>Bridge</name>
 	<description>A Bridge between Frontend and the Backend.</description>
+        <properties>
+                <quarkus.platform.version>2.10.4.Final</quarkus.platform.version>
+                <quarkus-plugin.version>2.10.4.Final</quarkus-plugin.version>
+        </properties>
 
 	<dependencyManagement>
 		<dependencies>

--- a/kogitoq/gadaq/src/main/resources/application.properties
+++ b/kogitoq/gadaq/src/main/resources/application.properties
@@ -40,6 +40,9 @@ mp.messaging.incoming.start_process_questions.value.deserializer=org.apache.kafk
 mp.messaging.outgoing.end_process_questions.connector=smallrye-kafka
 mp.messaging.outgoing.end_process_questions.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
+mp.messaging.outgoing.cancel_process_questions.connector=smallrye-kafka
+mp.messaging.outgoing.cancel_process_questions.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
 ## metadata
 
 #mp.messaging.outgoing.kogito-processinstances-events.bootstrap.servers=localhost:9092

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/ProcessQuestions.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/ProcessQuestions.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_wL4KgAD7EDunlrqeLZ__hQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_l1XIoAMqEDuxANBta72yyw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -17,6 +17,7 @@
   <bpmn2:itemDefinition id="_eventsItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_productCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_statusItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__759CAAA4-B6F4-407F-B937-8044B34DDE8E_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__89E1736F-871A-4A79-927B-EDF27526C798_processIdInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__89E1736F-871A-4A79-927B-EDF27526C798_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__89E1736F-871A-4A79-927B-EDF27526C798_existedOutputXItem" structureRef="Boolean"/>
@@ -60,7 +61,7 @@
   <bpmn2:itemDefinition id="__260DD51A-9F4F-468A-BC4C-B73012C9A5CC_processJsonInputXItem" structureRef="String"/>
   <bpmn2:signal id="_-1367724422" name="cancel"/>
   <bpmn2:interface id="_759CAAA4-B6F4-407F-B937-8044B34DDE8E_ServiceInterface" name="life.genny.kogito.common.service.NavigationService" implementationRef="life.genny.kogito.common.service.NavigationService">
-    <bpmn2:operation id="_759CAAA4-B6F4-407F-B937-8044B34DDE8E_ServiceOperation" name="redirect" implementationRef="redirect"/>
+    <bpmn2:operation id="_759CAAA4-B6F4-407F-B937-8044B34DDE8E_ServiceOperation" name="showProcessPage" implementationRef="showProcessPage"/>
   </bpmn2:interface>
   <bpmn2:interface id="_89E1736F-871A-4A79-927B-EDF27526C798_ServiceInterface" name="life.genny.kogito.common.service.ProcessAnswerService" implementationRef="life.genny.kogito.common.service.ProcessAnswerService">
     <bpmn2:operation id="_89E1736F-871A-4A79-927B-EDF27526C798_ServiceOperation" name="clearProcessCacheEntries" implementationRef="clearProcessCacheEntries"/>
@@ -120,8 +121,8 @@
   <bpmn2:interface id="_260DD51A-9F4F-468A-BC4C-B73012C9A5CC_ServiceInterface" name="life.genny.kogito.common.service.TaskService" implementationRef="life.genny.kogito.common.service.TaskService">
     <bpmn2:operation id="_260DD51A-9F4F-468A-BC4C-B73012C9A5CC_ServiceOperation" name="updateAskTarget" implementationRef="updateAskTarget"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_1B9C02F4-A046-4DDC-A92C-4E80C9D35380" name="Default Collaboration">
-    <bpmn2:participant id="_4C854B65-F296-405C-A510-0D931A9F2B9D" name="Pool Participant" processRef="processQuestions"/>
+  <bpmn2:collaboration id="_62DC7F56-2A3E-4094-8D44-0DBDFEC319F6" name="Default Collaboration">
+    <bpmn2:participant id="_FA6CBDF4-56CF-4938-8846-C8E881A889ED" name="Pool Participant" processRef="processQuestions"/>
   </bpmn2:collaboration>
   <bpmn2:process id="processQuestions" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Process Questions" isExecutable="true" processType="Public">
     <bpmn2:extensionElements>
@@ -242,13 +243,6 @@
         </drools:metaData>
       </bpmn2:extensionElements>
     </bpmn2:sequenceFlow>
-    <bpmn2:sequenceFlow id="_AA52BAC3-38DC-43DB-BDC2-D8B35006C864" sourceRef="_A8641089-DB8A-4893-A12E-97E3F9EF844A" targetRef="_47B49993-7B45-43B7-A239-DD642BA9BE1E">
-      <bpmn2:extensionElements>
-        <drools:metaData name="isAutoConnection.target">
-          <drools:metaValue><![CDATA[true]]></drools:metaValue>
-        </drools:metaData>
-      </bpmn2:extensionElements>
-    </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_AB4B1CE8-ECE1-4026-91D7-88B64BB2741F" sourceRef="_A8641089-DB8A-4893-A12E-97E3F9EF844A" targetRef="_73724C4D-1B60-4BA1-AC3E-3E7E49CE6F8D">
       <bpmn2:extensionElements>
         <drools:metaData name="isAutoConnection.target">
@@ -256,6 +250,13 @@
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return(sourceCode.equals(userCode));]]></bpmn2:conditionExpression>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_AA52BAC3-38DC-43DB-BDC2-D8B35006C864" sourceRef="_A8641089-DB8A-4893-A12E-97E3F9EF844A" targetRef="_47B49993-7B45-43B7-A239-DD642BA9BE1E">
+      <bpmn2:extensionElements>
+        <drools:metaData name="isAutoConnection.target">
+          <drools:metaValue><![CDATA[true]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_A00BF840-0AE4-4A43-ACC5-2AA118E4F17E" sourceRef="_D9299DD0-175D-4809-AAF6-7894CC081A4F" targetRef="_A8641089-DB8A-4893-A12E-97E3F9EF844A">
       <bpmn2:extensionElements>
@@ -275,9 +276,6 @@
     <bpmn2:sequenceFlow id="_4DF2EE21-8201-480B-86FD-E9FCF2F0A2FA" sourceRef="_4BC98AA9-DE2A-4833-B0AE-87896B35C7CC" targetRef="_8C431FA2-90B9-4AD6-96E3-F5B007A8F020"/>
     <bpmn2:sequenceFlow id="_A3D8C00C-3EC8-4E96-B720-88C3A7FB55EA" sourceRef="_BBDC9BAD-EFB7-494B-9120-6894F7A58912" targetRef="_4BC98AA9-DE2A-4833-B0AE-87896B35C7CC"/>
     <bpmn2:sequenceFlow id="_75489996-5813-4A85-BEEB-3ECA73052A3C" sourceRef="_8C431FA2-90B9-4AD6-96E3-F5B007A8F020" targetRef="_C79D1C8D-0391-42C9-A3E1-52DE6E69CC8D"/>
-    <bpmn2:sequenceFlow id="_C8D9EB5F-2563-4F02-B639-95807797473F" sourceRef="_587BE804-5FCF-4024-8B54-5815769452A9" targetRef="_A357D095-1565-40AF-B014-864C3E505203">
-      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return !alreadyExisting;]]></bpmn2:conditionExpression>
-    </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_77F42837-DC69-4202-BCED-ED7AB54B1B1D" name="Yes" sourceRef="_587BE804-5FCF-4024-8B54-5815769452A9" targetRef="_BBDC9BAD-EFB7-494B-9120-6894F7A58912">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
@@ -285,6 +283,9 @@
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return alreadyExisting;]]></bpmn2:conditionExpression>
+    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_C8D9EB5F-2563-4F02-B639-95807797473F" sourceRef="_587BE804-5FCF-4024-8B54-5815769452A9" targetRef="_A357D095-1565-40AF-B014-864C3E505203">
+      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return !alreadyExisting;]]></bpmn2:conditionExpression>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_A349EDB2-29DA-437C-8A9F-D483E7E985A2" sourceRef="_B0A31924-66B7-4462-AA7D-F2DA894988CC" targetRef="_587BE804-5FCF-4024-8B54-5815769452A9"/>
     <bpmn2:sequenceFlow id="_B02FCB82-04AA-4C9C-95D8-B8EEF2F5AB15" sourceRef="_2F5DA0FB-665B-488F-B4EC-C0B5069D3C79" targetRef="_B0A31924-66B7-4462-AA7D-F2DA894988CC">
@@ -517,8 +518,8 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
     </bpmn2:serviceTask>
     <bpmn2:exclusiveGateway id="_A8641089-DB8A-4893-A12E-97E3F9EF844A" drools:dg="_AA52BAC3-38DC-43DB-BDC2-D8B35006C864" gatewayDirection="Diverging" default="_AA52BAC3-38DC-43DB-BDC2-D8B35006C864">
       <bpmn2:incoming>_A00BF840-0AE4-4A43-ACC5-2AA118E4F17E</bpmn2:incoming>
-      <bpmn2:outgoing>_AB4B1CE8-ECE1-4026-91D7-88B64BB2741F</bpmn2:outgoing>
       <bpmn2:outgoing>_AA52BAC3-38DC-43DB-BDC2-D8B35006C864</bpmn2:outgoing>
+      <bpmn2:outgoing>_AB4B1CE8-ECE1-4026-91D7-88B64BB2741F</bpmn2:outgoing>
     </bpmn2:exclusiveGateway>
     <bpmn2:startEvent id="_6CFBA188-90A4-4833-ADEE-68B4D6A76D8E">
       <bpmn2:outgoing>_B0BC5BD4-07BA-456F-B0AD-33BD799C4E6D</bpmn2:outgoing>
@@ -599,8 +600,8 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
     </bpmn2:endEvent>
     <bpmn2:exclusiveGateway id="_587BE804-5FCF-4024-8B54-5815769452A9" drools:dg="_F3CDAC37-9BB4-40D1-977C-E32635FE7DD9" gatewayDirection="Diverging">
       <bpmn2:incoming>_A349EDB2-29DA-437C-8A9F-D483E7E985A2</bpmn2:incoming>
-      <bpmn2:outgoing>_77F42837-DC69-4202-BCED-ED7AB54B1B1D</bpmn2:outgoing>
       <bpmn2:outgoing>_C8D9EB5F-2563-4F02-B639-95807797473F</bpmn2:outgoing>
+      <bpmn2:outgoing>_77F42837-DC69-4202-BCED-ED7AB54B1B1D</bpmn2:outgoing>
     </bpmn2:exclusiveGateway>
     <bpmn2:scriptTask id="_B0A31924-66B7-4462-AA7D-F2DA894988CC" name="Check if Questions already asked?" scriptFormat="http://www.java.com/java">
       <bpmn2:extensionElements>
@@ -645,7 +646,18 @@ processId = kcontext.getProcessInstance().getId();
 kcontext.setVariable("processId",processId);
 mandatoryFieldsCompleted = false;
 System.out.println("New ProcessId="+processId);
-kcontext.setVariable("mandatoryFieldsCompleted",mandatoryFieldsCompleted);</bpmn2:script>
+kcontext.setVariable("mandatoryFieldsCompleted",mandatoryFieldsCompleted);
+if(data==null) {
+    data = new life.genny.kogito.common.models.S2SData();
+}
+data.setQuestionCode(questionCode);
+data.setSourceCode(sourceCode);
+data.setTargetCode(targetCode);
+data.setPcmCode(pcmCode);
+data.setEvents(events);
+data.setCancel(false);
+kcontext.setVariable("data",data);
+</bpmn2:script>
     </bpmn2:scriptTask>
     <bpmn2:subProcess id="_091DAD5E-7580-4FCB-A51D-BEA62012577D" triggeredByEvent="true">
       <bpmn2:sequenceFlow id="_2170F7DA-D745-48B8-ABBD-41804961DB09" sourceRef="_1C7502F2-13BA-48B4-9958-97552B478D49" targetRef="_2D994BEA-45F7-47FD-B712-BEE65A1273E9">
@@ -940,14 +952,6 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
       <bpmn2:sequenceFlow id="_CB98D165-DB0A-4BBD-854B-9097196648F1" sourceRef="_BD466960-7852-4DFA-BF92-309B4EA9A111" targetRef="_C9AC42A3-ACD1-42B8-B1C4-D1F56265C2F5"/>
       <bpmn2:sequenceFlow id="_C035803F-126A-4B38-A263-AAA4D9CE7AF7" sourceRef="_F97B4D15-8AFC-4665-ADC9-142AB7C47A38" targetRef="_D21052BD-9E84-46F3-9440-92F0251C3186"/>
       <bpmn2:sequenceFlow id="_A11F7237-2D7B-4DE9-B59E-EE8BD63C09CA" sourceRef="_831CA793-F61D-462F-9B8D-8FCE0CC20DFB" targetRef="_698E2BA2-7BE8-42A8-8A4C-B523B5A5FD2E"/>
-      <bpmn2:sequenceFlow id="_570CBB7A-FF3C-4343-A9B1-2817D86F6E37" name="No" sourceRef="_A9D04CFD-0C55-4F2C-B5CF-56B3667767F6" targetRef="_2263263D-EE9A-4DC8-A336-E946D7338019">
-        <bpmn2:extensionElements>
-          <drools:metaData name="elementname">
-            <drools:metaValue><![CDATA[No]]></drools:metaValue>
-          </drools:metaData>
-        </bpmn2:extensionElements>
-        <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return !mandatoryFieldsCompleted;]]></bpmn2:conditionExpression>
-      </bpmn2:sequenceFlow>
       <bpmn2:sequenceFlow id="_BBA42FA7-9723-4D63-8BBF-5C96BC12D1D7" name="Yes" sourceRef="_A9D04CFD-0C55-4F2C-B5CF-56B3667767F6" targetRef="_BD466960-7852-4DFA-BF92-309B4EA9A111">
         <bpmn2:extensionElements>
           <drools:metaData name="isAutoConnection.target">
@@ -958,6 +962,14 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
           </drools:metaData>
         </bpmn2:extensionElements>
         <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return mandatoryFieldsCompleted;]]></bpmn2:conditionExpression>
+      </bpmn2:sequenceFlow>
+      <bpmn2:sequenceFlow id="_570CBB7A-FF3C-4343-A9B1-2817D86F6E37" name="No" sourceRef="_A9D04CFD-0C55-4F2C-B5CF-56B3667767F6" targetRef="_2263263D-EE9A-4DC8-A336-E946D7338019">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[No]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return !mandatoryFieldsCompleted;]]></bpmn2:conditionExpression>
       </bpmn2:sequenceFlow>
       <bpmn2:sequenceFlow id="_F2644686-301A-433F-B5C6-1D15F7562ACB" sourceRef="_D21052BD-9E84-46F3-9440-92F0251C3186" targetRef="_A9D04CFD-0C55-4F2C-B5CF-56B3667767F6"/>
       <bpmn2:sequenceFlow id="_390377BD-4A3A-4372-97FB-52A9DE7B0F8F" sourceRef="_71AAC596-1331-41B6-B5E0-7428027D04FD" targetRef="_F97B4D15-8AFC-4665-ADC9-142AB7C47A38"/>
@@ -1106,8 +1118,8 @@ kcontext.setVariable("status", "COMPLETE");
       </bpmn2:endEvent>
       <bpmn2:exclusiveGateway id="_A9D04CFD-0C55-4F2C-B5CF-56B3667767F6" drools:dg="_570CBB7A-FF3C-4343-A9B1-2817D86F6E37" gatewayDirection="Diverging" default="_570CBB7A-FF3C-4343-A9B1-2817D86F6E37">
         <bpmn2:incoming>_F2644686-301A-433F-B5C6-1D15F7562ACB</bpmn2:incoming>
-        <bpmn2:outgoing>_BBA42FA7-9723-4D63-8BBF-5C96BC12D1D7</bpmn2:outgoing>
         <bpmn2:outgoing>_570CBB7A-FF3C-4343-A9B1-2817D86F6E37</bpmn2:outgoing>
+        <bpmn2:outgoing>_BBA42FA7-9723-4D63-8BBF-5C96BC12D1D7</bpmn2:outgoing>
       </bpmn2:exclusiveGateway>
       <bpmn2:startEvent id="_71AAC596-1331-41B6-B5E0-7428027D04FD" name="Submit Event">
         <bpmn2:extensionElements>
@@ -1120,10 +1132,29 @@ kcontext.setVariable("status", "COMPLETE");
       </bpmn2:startEvent>
     </bpmn2:subProcess>
     <bpmn2:subProcess id="_35E91B49-EBCD-434D-A365-D43DF886EE3F" triggeredByEvent="true">
+      <bpmn2:sequenceFlow id="_35C4070C-CAA2-43DB-A19E-4612E22DB7B8" sourceRef="_C00E5A92-93BF-4AAC-8796-3B487C279491" targetRef="_89E1736F-871A-4A79-927B-EDF27526C798"/>
       <bpmn2:sequenceFlow id="_26B6516D-8073-4422-98A2-3868994EEB79" sourceRef="_3998E07A-0264-4927-8D4B-EADCE34343C0" targetRef="_B974CC91-BB30-4C37-AF62-9B0871CDFBDF"/>
       <bpmn2:sequenceFlow id="_253B8478-063C-4E1F-9A9F-93F031303913" sourceRef="_759CAAA4-B6F4-407F-B937-8044B34DDE8E" targetRef="_3998E07A-0264-4927-8D4B-EADCE34343C0"/>
       <bpmn2:sequenceFlow id="_F0B3FE76-8AEC-4E25-945D-0E79095CD516" sourceRef="_89E1736F-871A-4A79-927B-EDF27526C798" targetRef="_759CAAA4-B6F4-407F-B937-8044B34DDE8E"/>
-      <bpmn2:sequenceFlow id="_5F40D4D4-170E-4E1C-8C4C-F8AD1EE21AD7" sourceRef="_CCFBDBFC-A2F1-4EC0-84AB-D2179B9AC3BE" targetRef="_89E1736F-871A-4A79-927B-EDF27526C798"/>
+      <bpmn2:sequenceFlow id="_5F40D4D4-170E-4E1C-8C4C-F8AD1EE21AD7" sourceRef="_CCFBDBFC-A2F1-4EC0-84AB-D2179B9AC3BE" targetRef="_C00E5A92-93BF-4AAC-8796-3B487C279491"/>
+      <bpmn2:scriptTask id="_C00E5A92-93BF-4AAC-8796-3B487C279491" name="Set Cancel Flag" scriptFormat="http://www.java.com/java">
+        <bpmn2:extensionElements>
+          <drools:metaData name="elementname">
+            <drools:metaValue><![CDATA[Set Cancel Flag]]></drools:metaValue>
+          </drools:metaData>
+        </bpmn2:extensionElements>
+        <bpmn2:incoming>_5F40D4D4-170E-4E1C-8C4C-F8AD1EE21AD7</bpmn2:incoming>
+        <bpmn2:outgoing>_35C4070C-CAA2-43DB-A19E-4612E22DB7B8</bpmn2:outgoing>
+        <bpmn2:script>System.out.println("Cancel detected in processQuestions");
+if (data!=null) {
+    System.out.println("data is not null:"+data);
+    data.setCancel(true);
+    kcontext.setVariable("data",data);
+} else {
+   System.out.println("data IS null:");
+ 
+}</bpmn2:script>
+      </bpmn2:scriptTask>
       <bpmn2:endEvent id="_B974CC91-BB30-4C37-AF62-9B0871CDFBDF">
         <bpmn2:incoming>_26B6516D-8073-4422-98A2-3868994EEB79</bpmn2:incoming>
         <bpmn2:terminateEventDefinition/>
@@ -1134,7 +1165,7 @@ kcontext.setVariable("status", "COMPLETE");
             <drools:metaValue><![CDATA[Clear Cache Entries]]></drools:metaValue>
           </drools:metaData>
         </bpmn2:extensionElements>
-        <bpmn2:incoming>_5F40D4D4-170E-4E1C-8C4C-F8AD1EE21AD7</bpmn2:incoming>
+        <bpmn2:incoming>_35C4070C-CAA2-43DB-A19E-4612E22DB7B8</bpmn2:incoming>
         <bpmn2:outgoing>_F0B3FE76-8AEC-4E25-945D-0E79095CD516</bpmn2:outgoing>
         <bpmn2:ioSpecification>
           <bpmn2:dataInput id="_89E1736F-871A-4A79-927B-EDF27526C798_processIdInputX" drools:dtype="String" itemSubjectRef="__89E1736F-871A-4A79-927B-EDF27526C798_processIdInputXItem" name="processId"/>
@@ -1171,7 +1202,7 @@ System.out.println (" questionCode = "+questionCode);
 System.out.println (" sourceCode = "+sourceCode);
 System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
       </bpmn2:scriptTask>
-      <bpmn2:serviceTask id="_759CAAA4-B6F4-407F-B937-8044B34DDE8E" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.NavigationService" drools:serviceoperation="redirect" name="Default Redirect" implementation="Java" operationRef="_759CAAA4-B6F4-407F-B937-8044B34DDE8E_ServiceOperation">
+      <bpmn2:serviceTask id="_759CAAA4-B6F4-407F-B937-8044B34DDE8E" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.NavigationService" drools:serviceoperation="showProcessPage" name="Default Redirect" implementation="Java" operationRef="_759CAAA4-B6F4-407F-B937-8044B34DDE8E_ServiceOperation">
         <bpmn2:extensionElements>
           <drools:metaData name="elementname">
             <drools:metaValue><![CDATA[Default Redirect]]></drools:metaValue>
@@ -1179,6 +1210,16 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
         </bpmn2:extensionElements>
         <bpmn2:incoming>_F0B3FE76-8AEC-4E25-945D-0E79095CD516</bpmn2:incoming>
         <bpmn2:outgoing>_253B8478-063C-4E1F-9A9F-93F031303913</bpmn2:outgoing>
+        <bpmn2:ioSpecification>
+          <bpmn2:dataInput id="_759CAAA4-B6F4-407F-B937-8044B34DDE8E_targetCodeInputX" drools:dtype="String" itemSubjectRef="__759CAAA4-B6F4-407F-B937-8044B34DDE8E_targetCodeInputXItem" name="targetCode"/>
+          <bpmn2:inputSet>
+            <bpmn2:dataInputRefs>_759CAAA4-B6F4-407F-B937-8044B34DDE8E_targetCodeInputX</bpmn2:dataInputRefs>
+          </bpmn2:inputSet>
+        </bpmn2:ioSpecification>
+        <bpmn2:dataInputAssociation>
+          <bpmn2:sourceRef>sourceCode</bpmn2:sourceRef>
+          <bpmn2:targetRef>_759CAAA4-B6F4-407F-B937-8044B34DDE8E_targetCodeInputX</bpmn2:targetRef>
+        </bpmn2:dataInputAssociation>
       </bpmn2:serviceTask>
       <bpmn2:startEvent id="_CCFBDBFC-A2F1-4EC0-84AB-D2179B9AC3BE" name="Cancel Event">
         <bpmn2:extensionElements>
@@ -1194,38 +1235,45 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
   <bpmndi:BPMNDiagram>
     <bpmndi:BPMNPlane bpmnElement="processQuestions">
       <bpmndi:BPMNShape id="shape__35E91B49-EBCD-434D-A365-D43DF886EE3F" bpmnElement="_35E91B49-EBCD-434D-A365-D43DF886EE3F" isExpanded="true">
-        <dc:Bounds height="142.07936507936506" width="845.7936507936511" x="269.1031746031745" y="1244.9603174603176"/>
+        <dc:Bounds height="147.07936507936506" width="1007.7936507936511" x="274.10317460317447" y="1243.4603174603176"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__CCFBDBFC-A2F1-4EC0-84AB-D2179B9AC3BE" bpmnElement="_CCFBDBFC-A2F1-4EC0-84AB-D2179B9AC3BE">
-        <dc:Bounds height="56" width="56" x="317.6031746031745" y="1292.9603174603176"/>
+        <dc:Bounds height="56" width="56" x="322.60317460317447" y="1291.4603174603176"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__759CAAA4-B6F4-407F-B937-8044B34DDE8E" bpmnElement="_759CAAA4-B6F4-407F-B937-8044B34DDE8E">
-        <dc:Bounds height="66.88888888888891" width="124.99999999999989" x="655.8253968253968" y="1287.9603174603176"/>
+        <dc:Bounds height="66.88888888888891" width="124.99999999999989" x="797.8253968253966" y="1285.4603174603176"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__3998E07A-0264-4927-8D4B-EADCE34343C0" bpmnElement="_3998E07A-0264-4927-8D4B-EADCE34343C0">
-        <dc:Bounds height="72" width="127" x="826.5" y="1284.9603174603176"/>
+        <dc:Bounds height="72" width="127" x="976" y="1284.4603174603176"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__89E1736F-871A-4A79-927B-EDF27526C798" bpmnElement="_89E1736F-871A-4A79-927B-EDF27526C798">
-        <dc:Bounds height="76" width="139.00000000000006" x="465.8253968253967" y="1283.404761904762"/>
+        <dc:Bounds height="76" width="139" x="613" y="1280"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__B974CC91-BB30-4C37-AF62-9B0871CDFBDF" bpmnElement="_B974CC91-BB30-4C37-AF62-9B0871CDFBDF">
-        <dc:Bounds height="56" width="56" x="999.3253968253966" y="1292.9603174603176"/>
+        <dc:Bounds height="56" width="56" x="1178" y="1291.5"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="edge_shape__CCFBDBFC-A2F1-4EC0-84AB-D2179B9AC3BE_to_shape__89E1736F-871A-4A79-927B-EDF27526C798" bpmnElement="_5F40D4D4-170E-4E1C-8C4C-F8AD1EE21AD7">
-        <di:waypoint x="345.6031746031745" y="1320.9603174603176"/>
-        <di:waypoint x="465.8253968253967" y="1321.404761904762"/>
+      <bpmndi:BPMNShape id="shape__C00E5A92-93BF-4AAC-8796-3B487C279491" bpmnElement="_C00E5A92-93BF-4AAC-8796-3B487C279491">
+        <dc:Bounds height="73" width="113" x="430.5" y="1281.5"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="edge_shape__CCFBDBFC-A2F1-4EC0-84AB-D2179B9AC3BE_to_shape__C00E5A92-93BF-4AAC-8796-3B487C279491" bpmnElement="_5F40D4D4-170E-4E1C-8C4C-F8AD1EE21AD7">
+        <di:waypoint x="350.60317460317447" y="1319.4603174603176"/>
+        <di:waypoint x="430.5" y="1318"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__89E1736F-871A-4A79-927B-EDF27526C798_to_shape__759CAAA4-B6F4-407F-B937-8044B34DDE8E" bpmnElement="_F0B3FE76-8AEC-4E25-945D-0E79095CD516">
-        <di:waypoint x="535.3253968253968" y="1321.404761904762"/>
-        <di:waypoint x="655.8253968253968" y="1321.404761904762"/>
+        <di:waypoint x="682.5" y="1318"/>
+        <di:waypoint x="797.8253968253966" y="1318.904761904762"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__759CAAA4-B6F4-407F-B937-8044B34DDE8E_to_shape__3998E07A-0264-4927-8D4B-EADCE34343C0" bpmnElement="_253B8478-063C-4E1F-9A9F-93F031303913">
-        <di:waypoint x="718.3253968253968" y="1321.404761904762"/>
-        <di:waypoint x="826.5" y="1320.9603174603176"/>
+        <di:waypoint x="860.3253968253966" y="1318.904761904762"/>
+        <di:waypoint x="976" y="1320.4603174603176"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__3998E07A-0264-4927-8D4B-EADCE34343C0_to_shape__B974CC91-BB30-4C37-AF62-9B0871CDFBDF" bpmnElement="_26B6516D-8073-4422-98A2-3868994EEB79">
-        <di:waypoint x="890" y="1320.9603174603176"/>
-        <di:waypoint x="999.3253968253966" y="1320.9603174603176"/>
+        <di:waypoint x="1039.5" y="1320.4603174603176"/>
+        <di:waypoint x="1178" y="1319.5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__C00E5A92-93BF-4AAC-8796-3B487C279491_to_shape__89E1736F-871A-4A79-927B-EDF27526C798" bpmnElement="_35C4070C-CAA2-43DB-A19E-4612E22DB7B8">
+        <di:waypoint x="487" y="1318"/>
+        <di:waypoint x="613" y="1318"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="shape__11A29A52-C9D0-4E65-BB61-661A380DF2EF" bpmnElement="_11A29A52-C9D0-4E65-BB61-661A380DF2EF" isExpanded="true">
         <dc:Bounds height="245" width="1264.1111111111113" x="272.2777777777778" y="980"/>
@@ -1268,13 +1316,13 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
         <di:waypoint x="659.7777777777778" y="1053.0137742268291"/>
         <di:waypoint x="762.2777777777778" y="1052.5"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__A9D04CFD-0C55-4F2C-B5CF-56B3667767F6_to_shape__BD466960-7852-4DFA-BF92-309B4EA9A111" bpmnElement="_BBA42FA7-9723-4D63-8BBF-5C96BC12D1D7">
-        <di:waypoint x="790.2777777777778" y="1052.5"/>
-        <di:waypoint x="866" y="1051.5"/>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__A9D04CFD-0C55-4F2C-B5CF-56B3667767F6_to_shape__2263263D-EE9A-4DC8-A336-E946D7338019" bpmnElement="_570CBB7A-FF3C-4343-A9B1-2817D86F6E37">
         <di:waypoint x="790.2777777777778" y="1052.5"/>
         <di:waypoint x="792.7777777777778" y="1154"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__A9D04CFD-0C55-4F2C-B5CF-56B3667767F6_to_shape__BD466960-7852-4DFA-BF92-309B4EA9A111" bpmnElement="_BBA42FA7-9723-4D63-8BBF-5C96BC12D1D7">
+        <di:waypoint x="790.2777777777778" y="1052.5"/>
+        <di:waypoint x="866" y="1051.5"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__831CA793-F61D-462F-9B8D-8FCE0CC20DFB_to_shape__698E2BA2-7BE8-42A8-8A4C-B523B5A5FD2E" bpmnElement="_A11F7237-2D7B-4DE9-B59E-EE8BD63C09CA">
         <di:waypoint x="1300" y="1051.5"/>
@@ -1297,7 +1345,7 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
         <di:waypoint x="893.7777777777778" y="1154"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="shape__9C8688B0-223C-435E-84C0-532ECC6DEBC6" bpmnElement="_9C8688B0-223C-435E-84C0-532ECC6DEBC6" isExpanded="true">
-        <dc:Bounds height="151.44444444444434" width="844.3333333333335" x="269.8333333333333" y="1405"/>
+        <dc:Bounds height="149.44444444444434" width="1006.3333333333335" x="269.8333333333333" y="1405"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__98993B97-BE4B-4E13-9B71-449E828B7802" bpmnElement="_98993B97-BE4B-4E13-9B71-449E828B7802">
         <dc:Bounds height="56" width="56" x="318.3333333333333" y="1453"/>
@@ -1477,14 +1525,14 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
         <di:waypoint x="950" y="113"/>
         <di:waypoint x="1104" y="112"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__587BE804-5FCF-4024-8B54-5815769452A9_to_shape__BBDC9BAD-EFB7-494B-9120-6894F7A58912" bpmnElement="_77F42837-DC69-4202-BCED-ED7AB54B1B1D">
-        <di:waypoint x="1132" y="112"/>
-        <di:waypoint x="1238" y="112"/>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__587BE804-5FCF-4024-8B54-5815769452A9_to_shape__A357D095-1565-40AF-B014-864C3E505203" bpmnElement="_C8D9EB5F-2563-4F02-B639-95807797473F">
         <di:waypoint x="1132" y="112"/>
         <di:waypoint x="1132" y="257"/>
         <di:waypoint x="1032.5" y="253.0183908045977"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__587BE804-5FCF-4024-8B54-5815769452A9_to_shape__BBDC9BAD-EFB7-494B-9120-6894F7A58912" bpmnElement="_77F42837-DC69-4202-BCED-ED7AB54B1B1D">
+        <di:waypoint x="1132" y="112"/>
+        <di:waypoint x="1238" y="112"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__8C431FA2-90B9-4AD6-96E3-F5B007A8F020_to_shape__C79D1C8D-0391-42C9-A3E1-52DE6E69CC8D" bpmnElement="_75489996-5813-4A85-BEEB-3ECA73052A3C">
         <di:waypoint x="1632" y="112"/>
@@ -1510,15 +1558,15 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
         <di:waypoint x="309.5" y="253"/>
         <di:waypoint x="310" y="386"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__A8641089-DB8A-4893-A12E-97E3F9EF844A_to_shape__73724C4D-1B60-4BA1-AC3E-3E7E49CE6F8D" bpmnElement="_AB4B1CE8-ECE1-4026-91D7-88B64BB2741F">
-        <di:waypoint x="310" y="414"/>
-        <di:waypoint x="424.1428571428571" y="414"/>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__A8641089-DB8A-4893-A12E-97E3F9EF844A_to_shape__47B49993-7B45-43B7-A239-DD642BA9BE1E" bpmnElement="_AA52BAC3-38DC-43DB-BDC2-D8B35006C864">
         <di:waypoint x="310" y="414"/>
         <di:waypoint x="309.9998519339759" y="518.5246111912777"/>
         <di:waypoint x="841" y="518.5246111912777"/>
         <di:waypoint x="842" y="442"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__A8641089-DB8A-4893-A12E-97E3F9EF844A_to_shape__73724C4D-1B60-4BA1-AC3E-3E7E49CE6F8D" bpmnElement="_AB4B1CE8-ECE1-4026-91D7-88B64BB2741F">
+        <di:waypoint x="310" y="414"/>
+        <di:waypoint x="424.1428571428571" y="414"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__3CDA056F-1838-4EA6-A1AD-53D93CB1B8FF_to_shape__2F5DA0FB-665B-488F-B4EC-C0B5069D3C79" bpmnElement="_C71AE1CB-27E1-46DD-989D-7607A8D99749">
         <di:waypoint x="552" y="112"/>
@@ -1805,7 +1853,7 @@ System.out.println (" targetCode = "+targetCode);  </bpmn2:script>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_wL4KgAD7EDunlrqeLZ__hQ</bpmn2:source>
-    <bpmn2:target>_wL4KgAD7EDunlrqeLZ__hQ</bpmn2:target>
+    <bpmn2:source>_l1XIoAMqEDuxANBta72yyw</bpmn2:source>
+    <bpmn2:target>_l1XIoAMqEDuxANBta72yyw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/ReceiveQuestionRequest.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/ReceiveQuestionRequest.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_WSYpgf51EDqxI_L0sQ3Nrw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_dqyNgAMiEDuWltZgJv8LZA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -15,28 +15,32 @@
   <bpmn2:itemDefinition id="_eventsItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__F07ACBC5-775B-4EB3-A5F2-491C4F0BFD21_eventOutputXItem" structureRef="life.genny.kogito.common.models.S2SData"/>
   <bpmn2:itemDefinition id="start_process_questionsType" structureRef="life.genny.kogito.common.models.S2SData"/>
-  <bpmn2:itemDefinition id="_CC23142C-AA13-4AB9-80E3-4A054939F854" structureRef=""/>
-  <bpmn2:itemDefinition id="_40D17CE9-9091-4C36-B8DA-06F86685F798" structureRef=""/>
+  <bpmn2:itemDefinition id="_FC604D3D-03A7-4022-93D5-E1AC36E22CB4" structureRef=""/>
+  <bpmn2:itemDefinition id="_42AE2AD7-B185-49B1-B454-6FC56E641D4D" structureRef=""/>
   <bpmn2:itemDefinition id="__AC12C7E3-434A-424B-B220-5C9CA5382BCC_dataInputXItem" structureRef="life.genny.kogito.common.models.S2SData"/>
   <bpmn2:itemDefinition id="__36C22626-601C-4362-8679-C175698C763C_eventInputXItem" structureRef="life.genny.kogito.common.models.S2SData"/>
-  <bpmn2:itemDefinition id="end_process_questionsType" structureRef="life.genny.kogito.common.models.S2SData"/>
+  <bpmn2:itemDefinition id="cancel_process_questionsType" structureRef="life.genny.kogito.common.models.S2SData"/>
   <bpmn2:itemDefinition id="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_questionCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_sourceCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_pcmCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_eventsInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_dataOutputXItem" structureRef="life.genny.kogito.common.models.S2SData"/>
   <bpmn2:itemDefinition id="__5E941DE0-7695-414D-AFBC-1940672ECDBC_dataInputXItem" structureRef="life.genny.kogito.common.models.S2SData"/>
   <bpmn2:itemDefinition id="__5E941DE0-7695-414D-AFBC-1940672ECDBC_dataOutputXItem" structureRef="life.genny.kogito.common.models.S2SData"/>
-  <bpmn2:message id="_WSbFwP51EDqxI_L0sQ3Nrw" itemRef="start_process_questionsType" name="start_process_questions"/>
+  <bpmn2:itemDefinition id="__9F4D91BB-FD35-44EA-86E0-292A01137A71_eventsInputXItem" structureRef="life.genny.kogito.common.models.S2SData"/>
+  <bpmn2:itemDefinition id="end_process_questionsType" structureRef="life.genny.kogito.common.models.S2SData"/>
+  <bpmn2:message id="_dq0CsAMiEDuWltZgJv8LZA" itemRef="start_process_questionsType" name="start_process_questions"/>
   <bpmn2:interface id="_AC12C7E3-434A-424B-B220-5C9CA5382BCC_ServiceInterface" name="life.genny.kogito.common.service.Service2Service" implementationRef="life.genny.kogito.common.service.Service2Service">
     <bpmn2:operation id="_AC12C7E3-434A-424B-B220-5C9CA5382BCC_ServiceOperation" name="initialiseScope" implementationRef="initialiseScope"/>
   </bpmn2:interface>
-  <bpmn2:message id="_WSbFwf51EDqxI_L0sQ3Nrw" itemRef="end_process_questionsType" name="end_process_questions"/>
+  <bpmn2:message id="_dq0CsQMiEDuWltZgJv8LZA" itemRef="cancel_process_questionsType" name="cancel_process_questions"/>
   <bpmn2:interface id="_5E941DE0-7695-414D-AFBC-1940672ECDBC_ServiceInterface" name="life.genny.kogito.common.service.Service2Service" implementationRef="life.genny.kogito.common.service.Service2Service">
     <bpmn2:operation id="_5E941DE0-7695-414D-AFBC-1940672ECDBC_ServiceOperation" name="addToken" implementationRef="addToken"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_999FE880-D3AD-4BD8-922A-DF0F5BB0AB35" name="Default Collaboration">
-    <bpmn2:participant id="_49951B76-B873-4969-9CA9-0D1983C23CEC" name="Pool Participant" processRef="receiveQuestionRequest"/>
+  <bpmn2:message id="_dq0pwAMiEDuWltZgJv8LZA" itemRef="end_process_questionsType" name="end_process_questions"/>
+  <bpmn2:collaboration id="_7A8FDE49-A577-475C-8373-F4D7B2E01CAB" name="Default Collaboration">
+    <bpmn2:participant id="_CA4BAD9A-DCB1-4CDD-81D8-AA6EBBC1D60E" name="Pool Participant" processRef="receiveQuestionRequest"/>
   </bpmn2:collaboration>
   <bpmn2:process id="receiveQuestionRequest" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Receive Question Request" isExecutable="true" processType="Public">
     <bpmn2:extensionElements>
@@ -80,6 +84,8 @@
       </bpmn2:extensionElements>
     </bpmn2:property>
     <bpmn2:property id="events" itemSubjectRef="_eventsItem" name="events"/>
+    <bpmn2:sequenceFlow id="_5A9C1A15-B5AF-430E-AF29-77041298B1F3" sourceRef="_D620A71D-6745-44D9-9C6D-657B8F82C9FD" targetRef="_9F4D91BB-FD35-44EA-86E0-292A01137A71"/>
+    <bpmn2:sequenceFlow id="_25D73BF4-701D-439C-95C1-5068F8629F0E" sourceRef="_5E941DE0-7695-414D-AFBC-1940672ECDBC" targetRef="_D620A71D-6745-44D9-9C6D-657B8F82C9FD"/>
     <bpmn2:sequenceFlow id="_5097238A-EA67-467A-AB2F-F925694DE7D8" sourceRef="_7F29E255-83EA-4D3A-B92B-1A792AECDD0F" targetRef="_5E941DE0-7695-414D-AFBC-1940672ECDBC">
       <bpmn2:extensionElements>
         <drools:metaData name="isAutoConnection.target">
@@ -87,7 +93,9 @@
         </drools:metaData>
       </bpmn2:extensionElements>
     </bpmn2:sequenceFlow>
-    <bpmn2:sequenceFlow id="_25D73BF4-701D-439C-95C1-5068F8629F0E" sourceRef="_5E941DE0-7695-414D-AFBC-1940672ECDBC" targetRef="_36C22626-601C-4362-8679-C175698C763C"/>
+    <bpmn2:sequenceFlow id="_096327D3-5F00-4B06-B8CE-011B57D2FC12" sourceRef="_D620A71D-6745-44D9-9C6D-657B8F82C9FD" targetRef="_36C22626-601C-4362-8679-C175698C763C">
+      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return data.isCancel();]]></bpmn2:conditionExpression>
+    </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_0E619AC8-C3A9-40DC-85CB-ACDCF20E3F92" sourceRef="_F07ACBC5-775B-4EB3-A5F2-491C4F0BFD21" targetRef="_AC12C7E3-434A-424B-B220-5C9CA5382BCC"/>
     <bpmn2:sequenceFlow id="_E4442815-B5A1-46E9-B9FF-C39D083BC314" sourceRef="_DA6AB090-7C32-42D5-9FF7-DB6FCBA0B1AC" targetRef="_7F29E255-83EA-4D3A-B92B-1A792AECDD0F">
       <bpmn2:extensionElements>
@@ -97,6 +105,28 @@
       </bpmn2:extensionElements>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_5098684C-954E-46E8-A0A5-9E81A54A16BA" sourceRef="_AC12C7E3-434A-424B-B220-5C9CA5382BCC" targetRef="_DA6AB090-7C32-42D5-9FF7-DB6FCBA0B1AC"/>
+    <bpmn2:exclusiveGateway id="_D620A71D-6745-44D9-9C6D-657B8F82C9FD" drools:dg="_5A9C1A15-B5AF-430E-AF29-77041298B1F3" gatewayDirection="Diverging" default="_5A9C1A15-B5AF-430E-AF29-77041298B1F3">
+      <bpmn2:incoming>_25D73BF4-701D-439C-95C1-5068F8629F0E</bpmn2:incoming>
+      <bpmn2:outgoing>_096327D3-5F00-4B06-B8CE-011B57D2FC12</bpmn2:outgoing>
+      <bpmn2:outgoing>_5A9C1A15-B5AF-430E-AF29-77041298B1F3</bpmn2:outgoing>
+    </bpmn2:exclusiveGateway>
+    <bpmn2:endEvent id="_9F4D91BB-FD35-44EA-86E0-292A01137A71" name="Submitted">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Submitted]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5A9C1A15-B5AF-430E-AF29-77041298B1F3</bpmn2:incoming>
+      <bpmn2:dataInput id="_9F4D91BB-FD35-44EA-86E0-292A01137A71_eventsInputX" drools:dtype="life.genny.kogito.common.models.S2SData" itemSubjectRef="__9F4D91BB-FD35-44EA-86E0-292A01137A71_eventsInputXItem" name="events"/>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>data</bpmn2:sourceRef>
+        <bpmn2:targetRef>_9F4D91BB-FD35-44EA-86E0-292A01137A71_eventsInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:inputSet>
+        <bpmn2:dataInputRefs>_9F4D91BB-FD35-44EA-86E0-292A01137A71_eventsInputX</bpmn2:dataInputRefs>
+      </bpmn2:inputSet>
+      <bpmn2:messageEventDefinition drools:msgref="end_process_questions" messageRef="_dq0pwAMiEDuWltZgJv8LZA"/>
+    </bpmn2:endEvent>
     <bpmn2:serviceTask id="_5E941DE0-7695-414D-AFBC-1940672ECDBC" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.Service2Service" drools:serviceoperation="addToken" name="Add Token" implementation="Java" operationRef="_5E941DE0-7695-414D-AFBC-1940672ECDBC_ServiceOperation">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
@@ -138,6 +168,7 @@
         <bpmn2:dataInput id="_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_targetCodeInputX" drools:dtype="String" itemSubjectRef="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_targetCodeInputXItem" name="targetCode"/>
         <bpmn2:dataInput id="_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_pcmCodeInputX" drools:dtype="String" itemSubjectRef="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_pcmCodeInputXItem" name="pcmCode"/>
         <bpmn2:dataInput id="_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_eventsInputX" drools:dtype="String" itemSubjectRef="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_eventsInputXItem" name="events"/>
+        <bpmn2:dataOutput id="_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_dataOutputX" drools:dtype="life.genny.kogito.common.models.S2SData" itemSubjectRef="__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_dataOutputXItem" name="data"/>
         <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_questionCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_sourceCodeInputX</bpmn2:dataInputRefs>
@@ -145,6 +176,9 @@
           <bpmn2:dataInputRefs>_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_pcmCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_eventsInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_dataOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
@@ -166,9 +200,18 @@
         <bpmn2:sourceRef>events</bpmn2:sourceRef>
         <bpmn2:targetRef>_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_eventsInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_7F29E255-83EA-4D3A-B92B-1A792AECDD0F_dataOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>data</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
     </bpmn2:callActivity>
-    <bpmn2:endEvent id="_36C22626-601C-4362-8679-C175698C763C">
-      <bpmn2:incoming>_25D73BF4-701D-439C-95C1-5068F8629F0E</bpmn2:incoming>
+    <bpmn2:endEvent id="_36C22626-601C-4362-8679-C175698C763C" name="Canceled">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Canceled]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_096327D3-5F00-4B06-B8CE-011B57D2FC12</bpmn2:incoming>
       <bpmn2:dataInput id="_36C22626-601C-4362-8679-C175698C763C_eventInputX" drools:dtype="life.genny.kogito.common.models.S2SData" itemSubjectRef="__36C22626-601C-4362-8679-C175698C763C_eventInputXItem" name="event"/>
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>data</bpmn2:sourceRef>
@@ -177,7 +220,7 @@
       <bpmn2:inputSet>
         <bpmn2:dataInputRefs>_36C22626-601C-4362-8679-C175698C763C_eventInputX</bpmn2:dataInputRefs>
       </bpmn2:inputSet>
-      <bpmn2:messageEventDefinition drools:msgref="end_process_questions" messageRef="_WSbFwf51EDqxI_L0sQ3Nrw"/>
+      <bpmn2:messageEventDefinition drools:msgref="cancel_process_questions" messageRef="_dq0CsQMiEDuWltZgJv8LZA"/>
     </bpmn2:endEvent>
     <bpmn2:serviceTask id="_AC12C7E3-434A-424B-B220-5C9CA5382BCC" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.Service2Service" drools:serviceoperation="initialiseScope" name="Scope Init" implementation="Java" operationRef="_AC12C7E3-434A-424B-B220-5C9CA5382BCC_ServiceOperation">
       <bpmn2:documentation><![CDATA[Initialise the request scope]]></bpmn2:documentation>
@@ -214,7 +257,7 @@
       <bpmn2:outputSet>
         <bpmn2:dataOutputRefs>_F07ACBC5-775B-4EB3-A5F2-491C4F0BFD21_eventOutputX</bpmn2:dataOutputRefs>
       </bpmn2:outputSet>
-      <bpmn2:messageEventDefinition drools:msgref="start_process_questions" messageRef="_WSbFwP51EDqxI_L0sQ3Nrw"/>
+      <bpmn2:messageEventDefinition drools:msgref="start_process_questions" messageRef="_dq0CsAMiEDuWltZgJv8LZA"/>
     </bpmn2:startEvent>
     <bpmn2:scriptTask id="_DA6AB090-7C32-42D5-9FF7-DB6FCBA0B1AC" name="Setup" scriptFormat="http://www.java.com/java">
       <bpmn2:extensionElements>
@@ -251,13 +294,19 @@ kcontext.setVariable("events", events);</bpmn2:script>
         <dc:Bounds height="102" width="154" x="318" y="109"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__36C22626-601C-4362-8679-C175698C763C" bpmnElement="_36C22626-601C-4362-8679-C175698C763C">
-        <dc:Bounds height="56" width="56" x="1246" y="132.12799999999996"/>
+        <dc:Bounds height="56" width="56" x="1306" y="294.12799999999993"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__7F29E255-83EA-4D3A-B92B-1A792AECDD0F" bpmnElement="_7F29E255-83EA-4D3A-B92B-1A792AECDD0F">
         <dc:Bounds height="101" width="153" x="774" y="110.00639755936524"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__5E941DE0-7695-414D-AFBC-1940672ECDBC" bpmnElement="_5E941DE0-7695-414D-AFBC-1940672ECDBC">
         <dc:Bounds height="102" width="154" x="1010" y="110"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__9F4D91BB-FD35-44EA-86E0-292A01137A71" bpmnElement="_9F4D91BB-FD35-44EA-86E0-292A01137A71">
+        <dc:Bounds height="56" width="56" x="1305.782070532695" y="132"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__D620A71D-6745-44D9-9C6D-657B8F82C9FD" bpmnElement="_D620A71D-6745-44D9-9C6D-657B8F82C9FD">
+        <dc:Bounds height="56" width="56" x="1216.3813003993876" y="132"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__AC12C7E3-434A-424B-B220-5C9CA5382BCC_to_shape__DA6AB090-7C32-42D5-9FF7-DB6FCBA0B1AC" bpmnElement="_5098684C-954E-46E8-A0A5-9E81A54A16BA">
         <di:waypoint x="395" y="160"/>
@@ -271,13 +320,22 @@ kcontext.setVariable("events", events);</bpmn2:script>
         <di:waypoint x="216" y="160"/>
         <di:waypoint x="318" y="160"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__5E941DE0-7695-414D-AFBC-1940672ECDBC_to_shape__36C22626-601C-4362-8679-C175698C763C" bpmnElement="_25D73BF4-701D-439C-95C1-5068F8629F0E">
-        <di:waypoint x="1087" y="161"/>
-        <di:waypoint x="1246" y="160.12799999999996"/>
+      <bpmndi:BPMNEdge id="edge_shape__D620A71D-6745-44D9-9C6D-657B8F82C9FD_to_shape__36C22626-601C-4362-8679-C175698C763C" bpmnElement="_096327D3-5F00-4B06-B8CE-011B57D2FC12">
+        <di:waypoint x="1244.3813003993876" y="160"/>
+        <di:waypoint x="1244.3813003993876" y="322.12799999999993"/>
+        <di:waypoint x="1306" y="322.12799999999993"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__7F29E255-83EA-4D3A-B92B-1A792AECDD0F_to_shape__5E941DE0-7695-414D-AFBC-1940672ECDBC" bpmnElement="_5097238A-EA67-467A-AB2F-F925694DE7D8">
         <di:waypoint x="850.5" y="160.50639755936524"/>
         <di:waypoint x="1010" y="161"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__5E941DE0-7695-414D-AFBC-1940672ECDBC_to_shape__D620A71D-6745-44D9-9C6D-657B8F82C9FD" bpmnElement="_25D73BF4-701D-439C-95C1-5068F8629F0E">
+        <di:waypoint x="1087" y="161"/>
+        <di:waypoint x="1216.3813003993876" y="160"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__D620A71D-6745-44D9-9C6D-657B8F82C9FD_to_shape__9F4D91BB-FD35-44EA-86E0-292A01137A71" bpmnElement="_5A9C1A15-B5AF-430E-AF29-77041298B1F3">
+        <di:waypoint x="1244.3813003993876" y="160"/>
+        <di:waypoint x="1305.782070532695" y="160"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
@@ -369,7 +427,7 @@ kcontext.setVariable("events", events);</bpmn2:script>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_WSYpgf51EDqxI_L0sQ3Nrw</bpmn2:source>
-    <bpmn2:target>_WSYpgf51EDqxI_L0sQ3Nrw</bpmn2:target>
+    <bpmn2:source>_dqyNgAMiEDuWltZgJv8LZA</bpmn2:source>
+    <bpmn2:target>_dqyNgAMiEDuWltZgJv8LZA</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/models/S2SData.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/models/S2SData.java
@@ -63,12 +63,10 @@ public class S2SData implements Serializable {
         this.token = token;
     }
 
-    /**
-     * @return String
-     */
     @Override
     public String toString() {
-        return "S2SData [questionCode=" + questionCode + "]";
+        return "S2SData [cancel=" + cancel + ", events=" + events + ", pcmCode=" + pcmCode + ", questionCode="
+                + questionCode + ", sourceCode=" + sourceCode + ", targetCode=" + targetCode + "]";
     }
 
     public Boolean getCancel() {

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
@@ -238,7 +238,7 @@ public class BaseEntityUtils {
 	 * @return The BaseEntity with code stored in the attribute
 	 */
 	public BaseEntity getBaseEntityFromLinkAttribute(BaseEntity baseEntity, String attributeCode) {
-		
+
 		String newBaseEntityCode = getBaseEntityCodeFromLinkAttribute(baseEntity, attributeCode);
 		// return null if attributeCode valueString is null or empty
 		if (StringUtils.isEmpty(newBaseEntityCode)) {
@@ -675,8 +675,8 @@ public class BaseEntityUtils {
 			throw new NullParameterException("be");
 		if (attributeCode == null)
 			throw new NullParameterException("attributeCode");
-		if (value == null)
-			throw new NullParameterException("value");
+		// if (value == null)
+		// throw new NullParameterException("value");
 
 		Attribute attribute = qwandaUtils.getAttribute(attributeCode);
 


### PR DESCRIPTION
This branch incorporates a cancel mechanism that is identified in the ReceiveQuestionRequest bpmn and then sends over a kafka message the appropriate response (submitted or canceled).
This pattern can be extended for other use cases.

The new questioning target is EEntityStatus.DELETED if canceled.
This ties in with the prd_internmatch that received the canceled message with a data (S2SData)

It should be compatible with lojing.