### PR TITLE
Revert "Updating logs"

### DIFF
--- a/kogitoq/gadaq/src/main/proto/list.json
+++ b/kogitoq/gadaq/src/main/proto/list.json
@@ -1,1 +1,1 @@
-["edit.proto","sendmessage.proto","view.proto","createBaseEntity.proto","testQuestion.proto","callProcessQuestions.proto","processQuestions.proto","authInit.proto","updatepcm.proto","receiveQuestionRequest.proto","personLifecycle.proto","sendData.proto"]
+["authInit.proto","sendmessage.proto","edit.proto","callProcessQuestions.proto","createBaseEntity.proto","sendData.proto","updatepcm.proto","view.proto","testQuestion.proto","personLifecycle.proto","processQuestions.proto","receiveQuestionRequest.proto"]

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/utils/KogitoUtils.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/utils/KogitoUtils.java
@@ -301,6 +301,7 @@ public class KogitoUtils {
 		// Insert Extras
 		session.insert(gqlUtils);
 		session.insert(qwandaUtils);
+		log.info("Inserting importGithubService into facts");
 		session.insert(importGithubService);
 		session.insert(msg);
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -93,11 +93,11 @@ public class QwandaUtils {
 
 	@PostConstruct
 	private void init() {
-		// Attribute submit = getAttribute("EVT_SUBMIT");
-		// if (submit == null) {
-		// log.error("Could not find Attribute: EVT_SUBMIT");
-		// }
-		// DTT_EVENT = submit.getDataType();
+		Attribute submit = getAttribute("EVT_SUBMIT");
+		if (submit == null) {
+			log.error("Could not find Attribute: EVT_SUBMIT");
+		}
+		DTT_EVENT = submit.getDataType();
 	}
 
 	public Attribute saveAttribute(final Attribute attribute) {


### PR DESCRIPTION
This reverts commit 814be0fe2c8a71a4999e156332010383b7fe6ad0. This commit was causing the datatypes not to be sent with the Attributes. I do not know how, but I systematically went back through each commit since the missing datatypes were detected and found the commit that they were breaking on. Luckily this commit is small, so the changes don't appear to be changing anything massive