### PR TITLE
Fixed npe

### DIFF
--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -78,7 +78,7 @@ public class RoleManager extends Manager {
 	public BaseEntity attachRole(BaseEntity target, String roleCode) {
 		
 		// Check we're working with a person
-		if(!target.isPerson())
+		if(target == null || !target.isPerson())
 			throw new RoleException("Error attaching role to target: " + target.getCode() + ". Target is not a person");
 		
 		roleCode = cleanRoleCode(roleCode);


### PR DESCRIPTION
Correctly throw an error for a null base entity being passed in to the attach role method