### PR TITLE
Fixed filter/clause container NPE in fyodor

### DIFF
--- a/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
@@ -84,6 +84,10 @@ public class CapHandler extends Manager {
 		info("Filtering " + containers.size() + " filters"); 
 		containers = containers.stream()
 				.filter(container -> {
+					// no filter => no capability requirements => let it through
+					if(container.getFilter() == null)
+						return true;
+					
 					info("Filtering " + container.getFilter().getCode());
 					return container.requirementsMet(userCapabilities);
 				})


### PR DESCRIPTION
This fixes the NPE in CapHandler in fyodor caused by ClauseContainers not always having a filter associated with them. The fix involves letting the ClauseContainer through the requirements check, since there is no associated filter to provide requirements for the Clause container.

Clause Containers may be deprecated in the near future (Filters serialise nicely in the TraitMap)