### PR TITLE
10.3.0 lojing edit alt

### DIFF
--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -193,11 +193,7 @@ public class Events {
 		if (ACT_EDIT.equals(code)) {
 
 			if (parentCode.startsWith("SBE_")) {
-				log.debug("[!] Retrieving edit question groups for target code: " + msg.getData().getTargetCode());
-				String[] questionCodes = qwandaUtils.getEditQuestionGroups(msg.getData().getTargetCode());
-				
 				JsonObject payload = Json.createObjectBuilder()
-						.add("questionCode", questionCodes[0])
 						.add("userCode", userToken.getUserCode())
 						.add("sourceCode", userToken.getUserCode())
 						.add("targetCode", msg.getData().getTargetCode())

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -204,7 +204,7 @@ public class Events {
 						.add("sourceCode", userToken.getUserCode())
 						.add("targetCode", msg.getData().getTargetCode())
 						.build();
-				kogitoUtils.triggerWorkflow(SELF, "testQuestion", payload);
+				kogitoUtils.triggerWorkflow(SELF, "edit", payload);
 				return;
 			}
 		}

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -202,7 +202,7 @@ public class Events {
 						.add("sourceCode", userToken.getUserCode())
 						.add("targetCode", msg.getData().getTargetCode())
 						.build();
-				kogitoUtils.triggerWorkflow(SELF, "processQuestions", payload);
+				kogitoUtils.triggerWorkflow(SELF, "edit", payload);
 				return;
 			}
 		}

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -193,6 +193,7 @@ public class Events {
 		if (ACT_EDIT.equals(code)) {
 
 			if (parentCode.startsWith("SBE_")) {
+				log.debug("[!] Retrieving edit question groups for target code: " + msg.getData().getTargetCode());
 				String[] questionCodes = qwandaUtils.getEditQuestionGroups(msg.getData().getTargetCode());
 				
 				JsonObject payload = Json.createObjectBuilder()

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -29,6 +29,7 @@ import life.genny.qwandaq.models.UserToken;
 import life.genny.qwandaq.utils.CacheUtils;
 import life.genny.qwandaq.utils.GraphQLUtils;
 import life.genny.qwandaq.utils.KafkaUtils;
+import life.genny.qwandaq.utils.QwandaUtils;
 import life.genny.gadaq.search.FilterGroupService;
 
 /**
@@ -54,8 +55,12 @@ public class Events {
 
 	@Inject
 	KogitoUtils kogitoUtils;
+
 	@Inject
 	GraphQLUtils gqlUtils;
+
+	@Inject
+	QwandaUtils qwandaUtils;
 
 	@Inject
 	NavigationService navigation;
@@ -187,11 +192,14 @@ public class Events {
 		}
 
 		// edit item (TODO This needs to be moved into a timer based bpmn)
-		if (ACT_EDIT.equals(code) && parentCode.startsWith(Prefix.SBE)) {
+		
+		if (ACT_EDIT.equals(code)) {
 
 			if (parentCode.startsWith("SBE_")) {
+				String[] questionCodes = qwandaUtils.getEditQuestionGroups(msg.getData().getTargetCode());
+				
 				JsonObject payload = Json.createObjectBuilder()
-						.add("questionCode", "QUE_BASEENTITY_GRP")
+						.add("questionCode", questionCodes[0])
 						.add("userCode", userToken.getUserCode())
 						.add("sourceCode", userToken.getUserCode())
 						.add("targetCode", msg.getData().getTargetCode())
@@ -199,9 +207,6 @@ public class Events {
 				kogitoUtils.triggerWorkflow(SELF, "testQuestion", payload);
 				return;
 			}
-
-			kogitoUtils.triggerWorkflow(SELF, "edit", "eventMessage", msg);
-			return;
 		}
 
 		/**

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -172,20 +172,17 @@ public class Events {
 			code = StringUtils.removeStart(code, QUE_ADD_);
 			String prefix = CacheUtils.getObject(userToken.getProductCode(), Prefix.DEF + code + ":PREFIX", String.class);
 
-			if ("PER".equals(prefix)) {
-				JsonObject json = Json.createObjectBuilder()
-						.add("definitionCode", "DEF_".concat(code))
-						.add("sourceCode", userToken.getUserCode())
-						.build();
+			JsonObject json = Json.createObjectBuilder()
+			.add("definitionCode", "DEF_".concat(code))
+			.add("sourceCode", userToken.getUserCode())
+			.build();
 
+			if ("PER".equals(prefix)) {
 				kogitoUtils.triggerWorkflow(SELF, "personLifecycle", json);
 				return;
-			}else if ("MSG".equals(prefix)){
-				JsonObject json = Json.createObjectBuilder()
-						.add("definitionCode", "DEF_".concat(code))
-						.add("sourceCode", userToken.getUserCode())
-						.build();
-
+			}
+			
+			if ("MSG".equals(prefix)) {
 				kogitoUtils.triggerWorkflow(SELF, "messageLifecycle", json);
 				return;
 			}

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -202,7 +202,7 @@ public class Events {
 						.add("sourceCode", userToken.getUserCode())
 						.add("targetCode", msg.getData().getTargetCode())
 						.build();
-				kogitoUtils.triggerWorkflow(SELF, "edit", payload);
+				kogitoUtils.triggerWorkflow(SELF, "processQuestions", payload);
 				return;
 			}
 		}

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_3kohsHlVEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_7bunsHlYEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -10,6 +10,7 @@
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
@@ -21,8 +22,8 @@
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_DC1FE585-FAAD-4A22-AFA9-4C799A12AFEE" name="Default Collaboration">
-    <bpmn2:participant id="_35C21EB5-9A8C-4B54-8258-DBC210E0F612" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_549921D0-BEBF-4EB1-999C-9E31B6DA119B" name="Default Collaboration">
+    <bpmn2:participant id="_2CDC1E13-9E7A-4576-BD65-6C3C2E0D7B81" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -122,12 +123,14 @@
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputXItem" name="targetCode"/>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputXItem" name="pcmCode"/>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" name="buttonEvents"/>
+        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" name="parent"/>
         <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation>
@@ -154,6 +157,13 @@
         <bpmn2:assignment>
           <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[SUBMIT,CANCEL,RESET]]></bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_EDIT"]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
     </bpmn2:callActivity>
@@ -317,7 +327,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_3kohsHlVEDuSffuN8Xf_nw</bpmn2:source>
-    <bpmn2:target>_3kohsHlVEDuSffuN8Xf_nw</bpmn2:target>
+    <bpmn2:source>_7bunsHlYEDuSffuN8Xf_nw</bpmn2:source>
+    <bpmn2:target>_7bunsHlYEDuSffuN8Xf_nw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_VGdZMHiYEDuqG_XbBd_nDQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_wcIw4HiYEDuqG_XbBd_nDQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -13,6 +13,7 @@
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:interface id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation" name="getBaseEntityQuestionGroup" implementationRef="getBaseEntityQuestionGroup"/>
@@ -20,8 +21,8 @@
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_0A886812-08E5-46A1-9BE3-13A8E6B03BF9" name="Default Collaboration">
-    <bpmn2:participant id="_D124CE75-C91C-4BF4-93DA-25BA92A19B3E" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_C2A5966B-32A8-4972-BEFA-BE3B161BFAE0" name="Default Collaboration">
+    <bpmn2:participant id="_97FCCA5F-8502-4C3E-B07E-DFD7BB172B4C" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -51,9 +52,11 @@
       <bpmn2:outgoing>_298C7DB0-C181-4AED-AD7E-CF5DC400045B</bpmn2:outgoing>
       <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" name="questionCode"/>
+        <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputXItem" name="PCMCode"/>
         <bpmn2:dataOutput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputXItem" name="questionCode"/>
         <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
         <bpmn2:outputSet>
           <bpmn2:dataOutputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX</bpmn2:dataOutputRefs>
@@ -62,6 +65,13 @@
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
         <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_FORM_EDIT"]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX]]></bpmn2:to>
+        </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
       <bpmn2:dataOutputAssociation>
         <bpmn2:sourceRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX</bpmn2:sourceRef>
@@ -307,7 +317,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_VGdZMHiYEDuqG_XbBd_nDQ</bpmn2:source>
-    <bpmn2:target>_VGdZMHiYEDuqG_XbBd_nDQ</bpmn2:target>
+    <bpmn2:source>_wcIw4HiYEDuqG_XbBd_nDQ</bpmn2:source>
+    <bpmn2:target>_wcIw4HiYEDuqG_XbBd_nDQ</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_KZ4OUHnjEDujpfchrs0tnA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_RpujYHnnEDujpfchrs0tnA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_pcmCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_processJsonItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_pcmCodeOutputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_parentInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_locationInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputXItem" structureRef="String"/>
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
-    <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="edit" implementationRef="edit"/>
+    <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="getEditPcmCode" implementationRef="getEditPcmCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_44B35716-4029-4D00-92B5-AB9D80E21B95" name="Default Collaboration">
-    <bpmn2:participant id="_F93C1ED2-E6A7-493B-A954-16D72D816919" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_4CBC4F27-36E9-4ECF-8405-69BB5D8A8CAA" name="Default Collaboration">
+    <bpmn2:participant id="_64F49D93-564D-44B0-B0D7-8BE07632A6B9" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -21,42 +26,97 @@
     <bpmn2:property id="targetCode" itemSubjectRef="_targetCodeItem" name="targetCode"/>
     <bpmn2:property id="pcmCode" itemSubjectRef="_pcmCodeItem" name="pcmCode"/>
     <bpmn2:property id="processJson" itemSubjectRef="_processJsonItem" name="processJson"/>
-    <bpmn2:sequenceFlow id="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
+    <bpmn2:sequenceFlow id="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A"/>
+    <bpmn2:sequenceFlow id="_7BB213A5-420C-4D89-AAA4-89B4CB0CB4E9" sourceRef="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
     <bpmn2:sequenceFlow id="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE" sourceRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" targetRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B"/>
     <bpmn2:sequenceFlow id="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2" sourceRef="_321CE5F6-80DE-48BD-93F4-41E832A810FF" targetRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2"/>
-    <bpmn2:serviceTask id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="edit" name="Edit" implementation="Java" operationRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation">
+    <bpmn2:callActivity id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" drools:independent="false" drools:waitForCompletion="true" name="ProcessQuestions - Edit" calledElement="">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
-          <drools:metaValue><![CDATA[Edit]]></drools:metaValue>
+          <drools:metaValue><![CDATA[ProcessQuestions - Edit]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_9F271F14-C9C3-409B-8B26-58A7BFD25BA1</bpmn2:incoming>
+      <bpmn2:outgoing>_7BB213A5-420C-4D89-AAA4-89B4CB0CB4E9</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputXItem" name="buttonEvents"/>
+        <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_parentInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_parentInputXItem" name="parent"/>
+        <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_locationInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_locationInputXItem" name="location"/>
+        <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputXItem" name="pcmCode"/>
+        <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputXItem" name="targetCode"/>
+        <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputXItem" name="sourceCode"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_parentInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_locationInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[Submit,Cancel,Reset]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_parentInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[PCM_CONTENT]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_parentInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_locationInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[PRI_LOC1]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_locationInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>pcmCode</bpmn2:sourceRef>
+        <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>targetCode</bpmn2:sourceRef>
+        <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>sourceCode</bpmn2:sourceRef>
+        <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:callActivity>
+    <bpmn2:serviceTask id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="getEditPcmCode" name="Find PCM Code" implementation="Java" operationRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Find PCM Code]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:incoming>_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE</bpmn2:incoming>
       <bpmn2:outgoing>_9F271F14-C9C3-409B-8B26-58A7BFD25BA1</bpmn2:outgoing>
       <bpmn2:ioSpecification>
-        <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" name="questionCode"/>
-        <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputXItem" name="sourceCode"/>
         <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputXItem" name="targetCode"/>
+        <bpmn2:dataOutput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_pcmCodeOutputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_pcmCodeOutputXItem" name="pcmCode"/>
         <bpmn2:inputSet>
-          <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_pcmCodeOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
       </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
-        <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:sourceRef>sourceCode</bpmn2:sourceRef>
-        <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputX</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>targetCode</bpmn2:sourceRef>
         <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_pcmCodeOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>pcmCode</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
     </bpmn2:serviceTask>
     <bpmn2:endEvent id="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
-      <bpmn2:incoming>_9F271F14-C9C3-409B-8B26-58A7BFD25BA1</bpmn2:incoming>
+      <bpmn2:incoming>_7BB213A5-420C-4D89-AAA4-89B4CB0CB4E9</bpmn2:incoming>
     </bpmn2:endEvent>
     <bpmn2:scriptTask id="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" name="Setup" scriptFormat="http://www.java.com/java">
       <bpmn2:extensionElements>
@@ -89,10 +149,13 @@ kcontext.setVariable("targetCode", targetCode);
         <dc:Bounds height="102" width="154" x="277" y="217"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
-        <dc:Bounds height="56" width="56" x="836" y="239.5"/>
+        <dc:Bounds height="56" width="56" x="1065" y="238.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_9D02C26B-B836-4E7D-8898-B32157CC6F5B">
-        <dc:Bounds height="102" width="154" x="571" y="216"/>
+        <dc:Bounds height="102" width="154" x="554" y="215"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" bpmnElement="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A">
+        <dc:Bounds height="101" width="153" x="818.5" y="216"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__321CE5F6-80DE-48BD-93F4-41E832A810FF_to_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" bpmnElement="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2">
         <di:waypoint x="178" y="267"/>
@@ -100,11 +163,15 @@ kcontext.setVariable("targetCode", targetCode);
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2_to_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE">
         <di:waypoint x="354" y="268"/>
-        <di:waypoint x="571" y="267"/>
+        <di:waypoint x="554" y="266"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1">
-        <di:waypoint x="648" y="267"/>
-        <di:waypoint x="836" y="267.5"/>
+      <bpmndi:BPMNEdge id="edge_shape__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_7BB213A5-420C-4D89-AAA4-89B4CB0CB4E9">
+        <di:waypoint x="895" y="266.5"/>
+        <di:waypoint x="1065" y="266.5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" bpmnElement="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1">
+        <di:waypoint x="631" y="266"/>
+        <di:waypoint x="818.5" y="266.5"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
@@ -160,10 +227,30 @@ kcontext.setVariable("targetCode", targetCode);
               </bpsim:UnitCost>
             </bpsim:CostParameters>
           </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_KZ4OUHnjEDujpfchrs0tnA</bpmn2:source>
-    <bpmn2:target>_KZ4OUHnjEDujpfchrs0tnA</bpmn2:target>
+    <bpmn2:source>_RpujYHnnEDujpfchrs0tnA</bpmn2:source>
+    <bpmn2:target>_RpujYHnnEDujpfchrs0tnA</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_MGszYHldEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_GJyTkHleEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -23,8 +23,8 @@
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_E42AF2EF-FC82-4D01-BF4E-B80134916CEB" name="Default Collaboration">
-    <bpmn2:participant id="_9D06339E-D0FB-46F7-8708-81B7C5AA36C9" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_BD16C187-4A1D-482C-9FFB-704DA0876AAD" name="Default Collaboration">
+    <bpmn2:participant id="_671C4A7D-3C07-4D40-9BF8-519007968BAF" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -35,7 +35,6 @@
     <bpmn2:property id="processJson" itemSubjectRef="_processJsonItem" name="processJson"/>
     <bpmn2:sequenceFlow id="_870F84DD-E321-459B-A790-EDF9ED7F708E" sourceRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" targetRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B"/>
     <bpmn2:sequenceFlow id="_19F1524D-103B-4708-BBE2-D0B5057346D1" sourceRef="_9A946931-A84E-4FB7-A34B-EE83E177F938" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
-    <bpmn2:sequenceFlow id="_298C7DB0-C181-4AED-AD7E-CF5DC400045B" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_9A946931-A84E-4FB7-A34B-EE83E177F938"/>
     <bpmn2:sequenceFlow id="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE" sourceRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" targetRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
       <bpmn2:extensionElements>
         <drools:metaData name="isAutoConnection.target">
@@ -51,7 +50,6 @@
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:incoming>_870F84DD-E321-459B-A790-EDF9ED7F708E</bpmn2:incoming>
-      <bpmn2:outgoing>_298C7DB0-C181-4AED-AD7E-CF5DC400045B</bpmn2:outgoing>
       <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" name="questionCode"/>
         <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputXItem" name="PCMCode"/>
@@ -116,7 +114,6 @@
           <drools:metaValue><![CDATA[Edit Item]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
-      <bpmn2:incoming>_298C7DB0-C181-4AED-AD7E-CF5DC400045B</bpmn2:incoming>
       <bpmn2:outgoing>_19F1524D-103B-4708-BBE2-D0B5057346D1</bpmn2:outgoing>
       <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputXItem" name="questionCode"/>
@@ -151,7 +148,7 @@
       <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX</bpmn2:targetRef>
         <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[PCM_FORM_EDIT]]></bpmn2:from>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_EDIT"]]></bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
@@ -208,7 +205,7 @@ kcontext.setVariable("targetCode", targetCode);
         <dc:Bounds height="102" width="154" x="277" y="217"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_9A946931-A84E-4FB7-A34B-EE83E177F938">
-        <dc:Bounds height="101" width="153" x="1073" y="216.5"/>
+        <dc:Bounds height="101" width="153" x="1058" y="216.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
         <dc:Bounds height="56" width="56" x="1329" y="238.5"/>
@@ -227,12 +224,8 @@ kcontext.setVariable("targetCode", targetCode);
         <di:waypoint x="354" y="268"/>
         <di:waypoint x="502" y="268"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_298C7DB0-C181-4AED-AD7E-CF5DC400045B">
-        <di:waypoint x="782" y="268"/>
-        <di:waypoint x="1073" y="267"/>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9A946931-A84E-4FB7-A34B-EE83E177F938_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_19F1524D-103B-4708-BBE2-D0B5057346D1">
-        <di:waypoint x="1149.5" y="267"/>
+        <di:waypoint x="1134.5" y="267"/>
         <di:waypoint x="1238" y="267"/>
         <di:waypoint x="1274" y="267"/>
         <di:waypoint x="1357" y="266.5"/>
@@ -338,7 +331,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_MGszYHldEDuSffuN8Xf_nw</bpmn2:source>
-    <bpmn2:target>_MGszYHldEDuSffuN8Xf_nw</bpmn2:target>
+    <bpmn2:source>_GJyTkHleEDuSffuN8Xf_nw</bpmn2:source>
+    <bpmn2:target>_GJyTkHleEDuSffuN8Xf_nw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_J0tNgHlbEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_MGszYHldEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -23,8 +23,8 @@
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_F3298B41-606C-41B8-9D6A-0EDB7FC0582A" name="Default Collaboration">
-    <bpmn2:participant id="_1DDAE15E-3F7B-4354-9925-BE5BB2D90788" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_E42AF2EF-FC82-4D01-BF4E-B80134916CEB" name="Default Collaboration">
+    <bpmn2:participant id="_9D06339E-D0FB-46F7-8708-81B7C5AA36C9" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -165,7 +165,7 @@
       <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX</bpmn2:targetRef>
         <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_EDIT"]]></bpmn2:from>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_CONTENT"]]></bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
@@ -208,10 +208,10 @@ kcontext.setVariable("targetCode", targetCode);
         <dc:Bounds height="102" width="154" x="277" y="217"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_9A946931-A84E-4FB7-A34B-EE83E177F938">
-        <dc:Bounds height="101" width="153" x="913" y="216.5"/>
+        <dc:Bounds height="101" width="153" x="1073" y="216.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
-        <dc:Bounds height="56" width="56" x="1160" y="238.5"/>
+        <dc:Bounds height="56" width="56" x="1329" y="238.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484" bpmnElement="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
         <dc:Bounds height="102" width="154" x="502" y="217"/>
@@ -229,12 +229,13 @@ kcontext.setVariable("targetCode", targetCode);
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_298C7DB0-C181-4AED-AD7E-CF5DC400045B">
         <di:waypoint x="782" y="268"/>
-        <di:waypoint x="913" y="267"/>
+        <di:waypoint x="1073" y="267"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9A946931-A84E-4FB7-A34B-EE83E177F938_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_19F1524D-103B-4708-BBE2-D0B5057346D1">
-        <di:waypoint x="989.5" y="267"/>
-        <di:waypoint x="1112" y="266.9900817107145"/>
-        <di:waypoint x="1188" y="266.5"/>
+        <di:waypoint x="1149.5" y="267"/>
+        <di:waypoint x="1238" y="267"/>
+        <di:waypoint x="1274" y="267"/>
+        <di:waypoint x="1357" y="266.5"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484_to_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_870F84DD-E321-459B-A790-EDF9ED7F708E">
         <di:waypoint x="579" y="268"/>
@@ -337,7 +338,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_J0tNgHlbEDuSffuN8Xf_nw</bpmn2:source>
-    <bpmn2:target>_J0tNgHlbEDuSffuN8Xf_nw</bpmn2:target>
+    <bpmn2:source>_MGszYHldEDuSffuN8Xf_nw</bpmn2:source>
+    <bpmn2:target>_MGszYHldEDuSffuN8Xf_nw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,30 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_GJyTkHleEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_qe-VwHnTEDujpfchrs0tnA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_pcmCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_processJsonItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:interface id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation" name="getBaseEntityQuestionGroup" implementationRef="getBaseEntityQuestionGroup"/>
   </bpmn2:interface>
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
-    <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
+    <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="edit" implementationRef="edit"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_BD16C187-4A1D-482C-9FFB-704DA0876AAD" name="Default Collaboration">
-    <bpmn2:participant id="_671C4A7D-3C07-4D40-9BF8-519007968BAF" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_9AAC5A12-FA00-4F74-870B-91D4D075656F" name="Default Collaboration">
+    <bpmn2:participant id="_6A97D5A9-3834-4D1C-A921-BDB85E54FB47" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -34,7 +27,7 @@
     <bpmn2:property id="pcmCode" itemSubjectRef="_pcmCodeItem" name="pcmCode"/>
     <bpmn2:property id="processJson" itemSubjectRef="_processJsonItem" name="processJson"/>
     <bpmn2:sequenceFlow id="_870F84DD-E321-459B-A790-EDF9ED7F708E" sourceRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" targetRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B"/>
-    <bpmn2:sequenceFlow id="_19F1524D-103B-4708-BBE2-D0B5057346D1" sourceRef="_9A946931-A84E-4FB7-A34B-EE83E177F938" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
+    <bpmn2:sequenceFlow id="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
     <bpmn2:sequenceFlow id="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE" sourceRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" targetRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
       <bpmn2:extensionElements>
         <drools:metaData name="isAutoConnection.target">
@@ -43,40 +36,36 @@
       </bpmn2:extensionElements>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2" sourceRef="_321CE5F6-80DE-48BD-93F4-41E832A810FF" targetRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2"/>
-    <bpmn2:serviceTask id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="setPcmQuestionCode" name="Set Question Code" implementation="Java" operationRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation">
+    <bpmn2:serviceTask id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="edit" name="Edit" implementation="Java" operationRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
-          <drools:metaValue><![CDATA[Set Question Code]]></drools:metaValue>
+          <drools:metaValue><![CDATA[Edit]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:incoming>_870F84DD-E321-459B-A790-EDF9ED7F708E</bpmn2:incoming>
+      <bpmn2:outgoing>_9F271F14-C9C3-409B-8B26-58A7BFD25BA1</bpmn2:outgoing>
       <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" name="questionCode"/>
-        <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputXItem" name="PCMCode"/>
-        <bpmn2:dataOutput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputXItem" name="questionCode"/>
+        <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputXItem" name="sourceCode"/>
+        <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputXItem" name="targetCode"/>
         <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
-        <bpmn2:outputSet>
-          <bpmn2:dataOutputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX</bpmn2:dataOutputRefs>
-        </bpmn2:outputSet>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
         <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
       <bpmn2:dataInputAssociation>
-        <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX</bpmn2:targetRef>
-        <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_FORM_EDIT"]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9D02C26B-B836-4E7D-8898-B32157CC6F5B_PCMCodeInputX]]></bpmn2:to>
-        </bpmn2:assignment>
+        <bpmn2:sourceRef>sourceCode</bpmn2:sourceRef>
+        <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataOutputAssociation>
-        <bpmn2:sourceRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX</bpmn2:sourceRef>
-        <bpmn2:targetRef>questionCode</bpmn2:targetRef>
-      </bpmn2:dataOutputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>targetCode</bpmn2:sourceRef>
+        <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
     </bpmn2:serviceTask>
     <bpmn2:serviceTask id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="getBaseEntityQuestionGroup" name="Find Question Code" implementation="Java" operationRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation">
       <bpmn2:extensionElements>
@@ -106,74 +95,8 @@
       </bpmn2:dataOutputAssociation>
     </bpmn2:serviceTask>
     <bpmn2:endEvent id="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
-      <bpmn2:incoming>_19F1524D-103B-4708-BBE2-D0B5057346D1</bpmn2:incoming>
+      <bpmn2:incoming>_9F271F14-C9C3-409B-8B26-58A7BFD25BA1</bpmn2:incoming>
     </bpmn2:endEvent>
-    <bpmn2:callActivity id="_9A946931-A84E-4FB7-A34B-EE83E177F938" drools:independent="true" drools:waitForCompletion="true" name="Edit Item" calledElement="processQuestions">
-      <bpmn2:extensionElements>
-        <drools:metaData name="elementname">
-          <drools:metaValue><![CDATA[Edit Item]]></drools:metaValue>
-        </drools:metaData>
-      </bpmn2:extensionElements>
-      <bpmn2:outgoing>_19F1524D-103B-4708-BBE2-D0B5057346D1</bpmn2:outgoing>
-      <bpmn2:ioSpecification>
-        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputXItem" name="questionCode"/>
-        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputXItem" name="sourceCode"/>
-        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputXItem" name="targetCode"/>
-        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputXItem" name="pcmCode"/>
-        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" name="buttonEvents"/>
-        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" name="parent"/>
-        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputXItem" name="location"/>
-        <bpmn2:inputSet>
-          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX</bpmn2:dataInputRefs>
-        </bpmn2:inputSet>
-      </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
-        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:sourceRef>sourceCode</bpmn2:sourceRef>
-        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputX</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:sourceRef>targetCode</bpmn2:sourceRef>
-        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_targetCodeInputX</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX</bpmn2:targetRef>
-        <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_EDIT"]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX]]></bpmn2:to>
-        </bpmn2:assignment>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX</bpmn2:targetRef>
-        <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[SUBMIT,CANCEL,RESET]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX]]></bpmn2:to>
-        </bpmn2:assignment>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX</bpmn2:targetRef>
-        <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_CONTENT"]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX]]></bpmn2:to>
-        </bpmn2:assignment>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX</bpmn2:targetRef>
-        <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PRI_LOC1"]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX]]></bpmn2:to>
-        </bpmn2:assignment>
-      </bpmn2:dataInputAssociation>
-    </bpmn2:callActivity>
     <bpmn2:scriptTask id="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" name="Setup" scriptFormat="http://www.java.com/java">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
@@ -204,17 +127,14 @@ kcontext.setVariable("targetCode", targetCode);
       <bpmndi:BPMNShape id="shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" bpmnElement="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2">
         <dc:Bounds height="102" width="154" x="277" y="217"/>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_9A946931-A84E-4FB7-A34B-EE83E177F938">
-        <dc:Bounds height="101" width="153" x="1058" y="216.5"/>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
-        <dc:Bounds height="56" width="56" x="1329" y="238.5"/>
+        <dc:Bounds height="56" width="56" x="975" y="238.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484" bpmnElement="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
-        <dc:Bounds height="102" width="154" x="502" y="217"/>
+        <dc:Bounds height="102" width="154" x="490" y="216"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_9D02C26B-B836-4E7D-8898-B32157CC6F5B">
-        <dc:Bounds height="102" width="154" x="705" y="217"/>
+        <dc:Bounds height="102" width="154" x="743" y="216"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__321CE5F6-80DE-48BD-93F4-41E832A810FF_to_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" bpmnElement="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2">
         <di:waypoint x="178" y="267"/>
@@ -222,17 +142,15 @@ kcontext.setVariable("targetCode", targetCode);
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2_to_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484" bpmnElement="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE">
         <di:waypoint x="354" y="268"/>
-        <di:waypoint x="502" y="268"/>
+        <di:waypoint x="490" y="267"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__9A946931-A84E-4FB7-A34B-EE83E177F938_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_19F1524D-103B-4708-BBE2-D0B5057346D1">
-        <di:waypoint x="1134.5" y="267"/>
-        <di:waypoint x="1238" y="267"/>
-        <di:waypoint x="1274" y="267"/>
-        <di:waypoint x="1357" y="266.5"/>
+      <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1">
+        <di:waypoint x="820" y="267"/>
+        <di:waypoint x="975" y="266.5"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484_to_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_870F84DD-E321-459B-A790-EDF9ED7F708E">
-        <di:waypoint x="579" y="268"/>
-        <di:waypoint x="705" y="268"/>
+        <di:waypoint x="567" y="267"/>
+        <di:waypoint x="743" y="267"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
@@ -249,26 +167,6 @@ kcontext.setVariable("targetCode", targetCode);
             </bpsim:TimeParameters>
           </bpsim:ElementParameters>
           <bpsim:ElementParameters elementRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2">
-            <bpsim:TimeParameters>
-              <bpsim:ProcessingTime>
-                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
-              </bpsim:ProcessingTime>
-            </bpsim:TimeParameters>
-            <bpsim:ResourceParameters>
-              <bpsim:Availability>
-                <bpsim:FloatingParameter value="0"/>
-              </bpsim:Availability>
-              <bpsim:Quantity>
-                <bpsim:FloatingParameter value="0"/>
-              </bpsim:Quantity>
-            </bpsim:ResourceParameters>
-            <bpsim:CostParameters>
-              <bpsim:UnitCost>
-                <bpsim:FloatingParameter value="0"/>
-              </bpsim:UnitCost>
-            </bpsim:CostParameters>
-          </bpsim:ElementParameters>
-          <bpsim:ElementParameters elementRef="_9A946931-A84E-4FB7-A34B-EE83E177F938">
             <bpsim:TimeParameters>
               <bpsim:ProcessingTime>
                 <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
@@ -331,7 +229,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_GJyTkHleEDuSffuN8Xf_nw</bpmn2:source>
-    <bpmn2:target>_GJyTkHleEDuSffuN8Xf_nw</bpmn2:target>
+    <bpmn2:source>_qe-VwHnTEDujpfchrs0tnA</bpmn2:source>
+    <bpmn2:target>_qe-VwHnTEDujpfchrs0tnA</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_0fFJMHlZEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_J0tNgHlbEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -12,7 +12,6 @@
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
@@ -24,8 +23,8 @@
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_468E0EFF-44FA-4B32-8AB9-EB1282F5298A" name="Default Collaboration">
-    <bpmn2:participant id="_E0000FF2-1642-406E-B517-9EAF592CD696" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_F3298B41-606C-41B8-9D6A-0EDB7FC0582A" name="Default Collaboration">
+    <bpmn2:participant id="_1DDAE15E-3F7B-4354-9925-BE5BB2D90788" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -127,7 +126,6 @@
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" name="buttonEvents"/>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" name="parent"/>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputXItem" name="location"/>
-        <bpmn2:dataOutput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputXItem" name="processJson"/>
         <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputX</bpmn2:dataInputRefs>
@@ -137,9 +135,6 @@
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
-        <bpmn2:outputSet>
-          <bpmn2:dataOutputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputX</bpmn2:dataOutputRefs>
-        </bpmn2:outputSet>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
@@ -181,10 +176,6 @@
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataOutputAssociation>
-        <bpmn2:sourceRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputX</bpmn2:sourceRef>
-        <bpmn2:targetRef>processJson</bpmn2:targetRef>
-      </bpmn2:dataOutputAssociation>
     </bpmn2:callActivity>
     <bpmn2:scriptTask id="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" name="Setup" scriptFormat="http://www.java.com/java">
       <bpmn2:extensionElements>
@@ -346,7 +337,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_0fFJMHlZEDuSffuN8Xf_nw</bpmn2:source>
-    <bpmn2:target>_0fFJMHlZEDuSffuN8Xf_nw</bpmn2:target>
+    <bpmn2:source>_J0tNgHlbEDuSffuN8Xf_nw</bpmn2:source>
+    <bpmn2:target>_J0tNgHlbEDuSffuN8Xf_nw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,23 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_qe-VwHnTEDujpfchrs0tnA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" xmlns:xsi="xsi" id="_KZ4OUHnjEDujpfchrs0tnA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_pcmCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_processJsonItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_sourceCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputXItem" structureRef="String"/>
-  <bpmn2:interface id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
-    <bpmn2:operation id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation" name="getBaseEntityQuestionGroup" implementationRef="getBaseEntityQuestionGroup"/>
-  </bpmn2:interface>
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="edit" implementationRef="edit"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_9AAC5A12-FA00-4F74-870B-91D4D075656F" name="Default Collaboration">
-    <bpmn2:participant id="_6A97D5A9-3834-4D1C-A921-BDB85E54FB47" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_44B35716-4029-4D00-92B5-AB9D80E21B95" name="Default Collaboration">
+    <bpmn2:participant id="_F93C1ED2-E6A7-493B-A954-16D72D816919" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -26,15 +21,8 @@
     <bpmn2:property id="targetCode" itemSubjectRef="_targetCodeItem" name="targetCode"/>
     <bpmn2:property id="pcmCode" itemSubjectRef="_pcmCodeItem" name="pcmCode"/>
     <bpmn2:property id="processJson" itemSubjectRef="_processJsonItem" name="processJson"/>
-    <bpmn2:sequenceFlow id="_870F84DD-E321-459B-A790-EDF9ED7F708E" sourceRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" targetRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B"/>
     <bpmn2:sequenceFlow id="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
-    <bpmn2:sequenceFlow id="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE" sourceRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" targetRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
-      <bpmn2:extensionElements>
-        <drools:metaData name="isAutoConnection.target">
-          <drools:metaValue><![CDATA[true]]></drools:metaValue>
-        </drools:metaData>
-      </bpmn2:extensionElements>
-    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE" sourceRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" targetRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B"/>
     <bpmn2:sequenceFlow id="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2" sourceRef="_321CE5F6-80DE-48BD-93F4-41E832A810FF" targetRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2"/>
     <bpmn2:serviceTask id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="edit" name="Edit" implementation="Java" operationRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation">
       <bpmn2:extensionElements>
@@ -42,7 +30,7 @@
           <drools:metaValue><![CDATA[Edit]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
-      <bpmn2:incoming>_870F84DD-E321-459B-A790-EDF9ED7F708E</bpmn2:incoming>
+      <bpmn2:incoming>_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE</bpmn2:incoming>
       <bpmn2:outgoing>_9F271F14-C9C3-409B-8B26-58A7BFD25BA1</bpmn2:outgoing>
       <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" name="questionCode"/>
@@ -66,33 +54,6 @@
         <bpmn2:sourceRef>targetCode</bpmn2:sourceRef>
         <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-    </bpmn2:serviceTask>
-    <bpmn2:serviceTask id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="getBaseEntityQuestionGroup" name="Find Question Code" implementation="Java" operationRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation">
-      <bpmn2:extensionElements>
-        <drools:metaData name="elementname">
-          <drools:metaValue><![CDATA[Find Question Code]]></drools:metaValue>
-        </drools:metaData>
-      </bpmn2:extensionElements>
-      <bpmn2:incoming>_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE</bpmn2:incoming>
-      <bpmn2:outgoing>_870F84DD-E321-459B-A790-EDF9ED7F708E</bpmn2:outgoing>
-      <bpmn2:ioSpecification>
-        <bpmn2:dataInput id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputX" drools:dtype="String" itemSubjectRef="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" name="targetCode"/>
-        <bpmn2:dataOutput id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputX" drools:dtype="String" itemSubjectRef="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" name="questionCode"/>
-        <bpmn2:inputSet>
-          <bpmn2:dataInputRefs>_215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputX</bpmn2:dataInputRefs>
-        </bpmn2:inputSet>
-        <bpmn2:outputSet>
-          <bpmn2:dataOutputRefs>_215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputX</bpmn2:dataOutputRefs>
-        </bpmn2:outputSet>
-      </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation>
-        <bpmn2:sourceRef>targetCode</bpmn2:sourceRef>
-        <bpmn2:targetRef>_215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputX</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataOutputAssociation>
-        <bpmn2:sourceRef>_215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputX</bpmn2:sourceRef>
-        <bpmn2:targetRef>questionCode</bpmn2:targetRef>
-      </bpmn2:dataOutputAssociation>
     </bpmn2:serviceTask>
     <bpmn2:endEvent id="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
       <bpmn2:incoming>_9F271F14-C9C3-409B-8B26-58A7BFD25BA1</bpmn2:incoming>
@@ -128,29 +89,22 @@ kcontext.setVariable("targetCode", targetCode);
         <dc:Bounds height="102" width="154" x="277" y="217"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
-        <dc:Bounds height="56" width="56" x="975" y="238.5"/>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484" bpmnElement="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
-        <dc:Bounds height="102" width="154" x="490" y="216"/>
+        <dc:Bounds height="56" width="56" x="836" y="239.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_9D02C26B-B836-4E7D-8898-B32157CC6F5B">
-        <dc:Bounds height="102" width="154" x="743" y="216"/>
+        <dc:Bounds height="102" width="154" x="571" y="216"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__321CE5F6-80DE-48BD-93F4-41E832A810FF_to_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" bpmnElement="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2">
         <di:waypoint x="178" y="267"/>
         <di:waypoint x="354" y="268"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2_to_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484" bpmnElement="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE">
+      <bpmndi:BPMNEdge id="edge_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2_to_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE">
         <di:waypoint x="354" y="268"/>
-        <di:waypoint x="490" y="267"/>
+        <di:waypoint x="571" y="267"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1">
-        <di:waypoint x="820" y="267"/>
-        <di:waypoint x="975" y="266.5"/>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484_to_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_870F84DD-E321-459B-A790-EDF9ED7F708E">
-        <di:waypoint x="567" y="267"/>
-        <di:waypoint x="743" y="267"/>
+        <di:waypoint x="648" y="267"/>
+        <di:waypoint x="836" y="267.5"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
@@ -167,26 +121,6 @@ kcontext.setVariable("targetCode", targetCode);
             </bpsim:TimeParameters>
           </bpsim:ElementParameters>
           <bpsim:ElementParameters elementRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2">
-            <bpsim:TimeParameters>
-              <bpsim:ProcessingTime>
-                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
-              </bpsim:ProcessingTime>
-            </bpsim:TimeParameters>
-            <bpsim:ResourceParameters>
-              <bpsim:Availability>
-                <bpsim:FloatingParameter value="0"/>
-              </bpsim:Availability>
-              <bpsim:Quantity>
-                <bpsim:FloatingParameter value="0"/>
-              </bpsim:Quantity>
-            </bpsim:ResourceParameters>
-            <bpsim:CostParameters>
-              <bpsim:UnitCost>
-                <bpsim:FloatingParameter value="0"/>
-              </bpsim:UnitCost>
-            </bpsim:CostParameters>
-          </bpsim:ElementParameters>
-          <bpsim:ElementParameters elementRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
             <bpsim:TimeParameters>
               <bpsim:ProcessingTime>
                 <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
@@ -229,7 +163,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_qe-VwHnTEDujpfchrs0tnA</bpmn2:source>
-    <bpmn2:target>_qe-VwHnTEDujpfchrs0tnA</bpmn2:target>
+    <bpmn2:source>_KZ4OUHnjEDujpfchrs0tnA</bpmn2:source>
+    <bpmn2:target>_KZ4OUHnjEDujpfchrs0tnA</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_iH3rkHhMEDuVc9A98Ze06Q" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_VGdZMHiYEDuqG_XbBd_nDQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -12,11 +12,16 @@
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:interface id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation" name="getBaseEntityQuestionGroup" implementationRef="getBaseEntityQuestionGroup"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_8789523E-8667-497B-9F93-A61CEA3A75C6" name="Default Collaboration">
-    <bpmn2:participant id="_5F927776-BCBA-41D4-942E-E1C536329A39" name="Pool Participant" processRef="edit"/>
+  <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
+    <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
+  </bpmn2:interface>
+  <bpmn2:collaboration id="_0A886812-08E5-46A1-9BE3-13A8E6B03BF9" name="Default Collaboration">
+    <bpmn2:participant id="_D124CE75-C91C-4BF4-93DA-25BA92A19B3E" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -25,14 +30,9 @@
     <bpmn2:property id="targetCode" itemSubjectRef="_targetCodeItem" name="targetCode"/>
     <bpmn2:property id="pcmCode" itemSubjectRef="_pcmCodeItem" name="pcmCode"/>
     <bpmn2:property id="processJson" itemSubjectRef="_processJsonItem" name="processJson"/>
+    <bpmn2:sequenceFlow id="_870F84DD-E321-459B-A790-EDF9ED7F708E" sourceRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" targetRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B"/>
     <bpmn2:sequenceFlow id="_19F1524D-103B-4708-BBE2-D0B5057346D1" sourceRef="_9A946931-A84E-4FB7-A34B-EE83E177F938" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
-    <bpmn2:sequenceFlow id="_870F84DD-E321-459B-A790-EDF9ED7F708E" sourceRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" targetRef="_9A946931-A84E-4FB7-A34B-EE83E177F938">
-      <bpmn2:extensionElements>
-        <drools:metaData name="isAutoConnection.target">
-          <drools:metaValue><![CDATA[true]]></drools:metaValue>
-        </drools:metaData>
-      </bpmn2:extensionElements>
-    </bpmn2:sequenceFlow>
+    <bpmn2:sequenceFlow id="_298C7DB0-C181-4AED-AD7E-CF5DC400045B" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_9A946931-A84E-4FB7-A34B-EE83E177F938"/>
     <bpmn2:sequenceFlow id="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE" sourceRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" targetRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
       <bpmn2:extensionElements>
         <drools:metaData name="isAutoConnection.target">
@@ -41,6 +41,33 @@
       </bpmn2:extensionElements>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2" sourceRef="_321CE5F6-80DE-48BD-93F4-41E832A810FF" targetRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2"/>
+    <bpmn2:serviceTask id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="setPcmQuestionCode" name="Set Question Code" implementation="Java" operationRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Set Question Code]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_870F84DD-E321-459B-A790-EDF9ED7F708E</bpmn2:incoming>
+      <bpmn2:outgoing>_298C7DB0-C181-4AED-AD7E-CF5DC400045B</bpmn2:outgoing>
+      <bpmn2:ioSpecification>
+        <bpmn2:dataInput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" name="questionCode"/>
+        <bpmn2:dataOutput id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX" drools:dtype="String" itemSubjectRef="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputXItem" name="questionCode"/>
+        <bpmn2:inputSet>
+          <bpmn2:dataInputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
+        <bpmn2:targetRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputX</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>questionCode</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:serviceTask>
     <bpmn2:serviceTask id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="getBaseEntityQuestionGroup" name="Find Question Code" implementation="Java" operationRef="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
@@ -77,7 +104,7 @@
           <drools:metaValue><![CDATA[Edit Item]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
-      <bpmn2:incoming>_870F84DD-E321-459B-A790-EDF9ED7F708E</bpmn2:incoming>
+      <bpmn2:incoming>_298C7DB0-C181-4AED-AD7E-CF5DC400045B</bpmn2:incoming>
       <bpmn2:outgoing>_19F1524D-103B-4708-BBE2-D0B5057346D1</bpmn2:outgoing>
       <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputXItem" name="questionCode"/>
@@ -151,13 +178,16 @@ kcontext.setVariable("targetCode", targetCode);
         <dc:Bounds height="102" width="154" x="277" y="217"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_9A946931-A84E-4FB7-A34B-EE83E177F938">
-        <dc:Bounds height="101" width="153" x="727" y="217"/>
+        <dc:Bounds height="101" width="153" x="913" y="216.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_6B57FB09-0C73-46CA-92B3-5D158B176FD4">
-        <dc:Bounds height="56" width="56" x="952" y="239.5"/>
+        <dc:Bounds height="56" width="56" x="1160" y="238.5"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484" bpmnElement="_215E8D3C-AA93-42FA-AA3D-7ED10509D484">
-        <dc:Bounds height="102" width="154" x="501" y="217"/>
+        <dc:Bounds height="102" width="154" x="502" y="217"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_9D02C26B-B836-4E7D-8898-B32157CC6F5B">
+        <dc:Bounds height="102" width="154" x="705" y="217"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__321CE5F6-80DE-48BD-93F4-41E832A810FF_to_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" bpmnElement="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2">
         <di:waypoint x="178" y="267"/>
@@ -165,15 +195,20 @@ kcontext.setVariable("targetCode", targetCode);
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2_to_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484" bpmnElement="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE">
         <di:waypoint x="354" y="268"/>
-        <di:waypoint x="501" y="268"/>
+        <di:waypoint x="502" y="268"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484_to_shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_870F84DD-E321-459B-A790-EDF9ED7F708E">
-        <di:waypoint x="578" y="268"/>
-        <di:waypoint x="727" y="267.5"/>
+      <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__9A946931-A84E-4FB7-A34B-EE83E177F938" bpmnElement="_298C7DB0-C181-4AED-AD7E-CF5DC400045B">
+        <di:waypoint x="782" y="268"/>
+        <di:waypoint x="913" y="267"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9A946931-A84E-4FB7-A34B-EE83E177F938_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_19F1524D-103B-4708-BBE2-D0B5057346D1">
-        <di:waypoint x="803.5" y="267.5"/>
-        <di:waypoint x="980" y="267.5"/>
+        <di:waypoint x="989.5" y="267"/>
+        <di:waypoint x="1112" y="266.9900817107145"/>
+        <di:waypoint x="1188" y="266.5"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__215E8D3C-AA93-42FA-AA3D-7ED10509D484_to_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B" bpmnElement="_870F84DD-E321-459B-A790-EDF9ED7F708E">
+        <di:waypoint x="579" y="268"/>
+        <di:waypoint x="705" y="268"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
@@ -249,10 +284,30 @@ kcontext.setVariable("targetCode", targetCode);
               </bpsim:UnitCost>
             </bpsim:CostParameters>
           </bpsim:ElementParameters>
+          <bpsim:ElementParameters elementRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_iH3rkHhMEDuVc9A98Ze06Q</bpmn2:source>
-    <bpmn2:target>_iH3rkHhMEDuVc9A98Ze06Q</bpmn2:target>
+    <bpmn2:source>_VGdZMHiYEDuqG_XbBd_nDQ</bpmn2:source>
+    <bpmn2:target>_VGdZMHiYEDuqG_XbBd_nDQ</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_3ypUcFKFEDu3hPCZlFG7dw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_iH3rkHhMEDuVc9A98Ze06Q" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -15,8 +15,8 @@
   <bpmn2:interface id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_215E8D3C-AA93-42FA-AA3D-7ED10509D484_ServiceOperation" name="getBaseEntityQuestionGroup" implementationRef="getBaseEntityQuestionGroup"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_33D7BB2E-D72E-4C8F-BC36-684D2B441D32" name="Default Collaboration">
-    <bpmn2:participant id="_F1CE9E5F-0108-4ABE-9397-27C3E7A982F2" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_8789523E-8667-497B-9F93-A61CEA3A75C6" name="Default Collaboration">
+    <bpmn2:participant id="_5F927776-BCBA-41D4-942E-E1C536329A39" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -108,7 +108,7 @@
       <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX</bpmn2:targetRef>
         <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[PCM_FORM]]></bpmn2:from>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_EDIT"]]></bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
@@ -252,7 +252,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_3ypUcFKFEDu3hPCZlFG7dw</bpmn2:source>
-    <bpmn2:target>_3ypUcFKFEDu3hPCZlFG7dw</bpmn2:target>
+    <bpmn2:source>_iH3rkHhMEDuVc9A98Ze06Q</bpmn2:source>
+    <bpmn2:target>_iH3rkHhMEDuVc9A98Ze06Q</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_7bunsHlYEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_0fFJMHlZEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -11,6 +11,8 @@
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__215E8D3C-AA93-42FA-AA3D-7ED10509D484_questionCodeOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_questionCodeInputXItem" structureRef="String"/>
@@ -22,8 +24,8 @@
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_549921D0-BEBF-4EB1-999C-9E31B6DA119B" name="Default Collaboration">
-    <bpmn2:participant id="_2CDC1E13-9E7A-4576-BD65-6C3C2E0D7B81" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_468E0EFF-44FA-4B32-8AB9-EB1282F5298A" name="Default Collaboration">
+    <bpmn2:participant id="_E0000FF2-1642-406E-B517-9EAF592CD696" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -124,6 +126,8 @@
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputXItem" name="pcmCode"/>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputXItem" name="buttonEvents"/>
         <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputXItem" name="parent"/>
+        <bpmn2:dataInput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputXItem" name="location"/>
+        <bpmn2:dataOutput id="_9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputX" drools:dtype="String" itemSubjectRef="__9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputXItem" name="processJson"/>
         <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_questionCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_sourceCodeInputX</bpmn2:dataInputRefs>
@@ -131,7 +135,11 @@
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_buttonEventsInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>questionCode</bpmn2:sourceRef>
@@ -166,6 +174,17 @@
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_parentInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation>
+        <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX</bpmn2:targetRef>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PRI_LOC1"]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_locationInputX]]></bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_processJsonOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>processJson</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
     </bpmn2:callActivity>
     <bpmn2:scriptTask id="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" name="Setup" scriptFormat="http://www.java.com/java">
       <bpmn2:extensionElements>
@@ -327,7 +346,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_7bunsHlYEDuSffuN8Xf_nw</bpmn2:source>
-    <bpmn2:target>_7bunsHlYEDuSffuN8Xf_nw</bpmn2:target>
+    <bpmn2:source>_0fFJMHlZEDuSffuN8Xf_nw</bpmn2:source>
+    <bpmn2:target>_0fFJMHlZEDuSffuN8Xf_nw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_wcIw4HiYEDuqG_XbBd_nDQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_3kohsHlVEDuSffuN8Xf_nw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -21,8 +21,8 @@
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="setPcmQuestionCode" implementationRef="setPcmQuestionCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_C2A5966B-32A8-4972-BEFA-BE3B161BFAE0" name="Default Collaboration">
-    <bpmn2:participant id="_97FCCA5F-8502-4C3E-B07E-DFD7BB172B4C" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_DC1FE585-FAAD-4A22-AFA9-4C799A12AFEE" name="Default Collaboration">
+    <bpmn2:participant id="_35C21EB5-9A8C-4B54-8258-DBC210E0F612" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -145,7 +145,7 @@
       <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX</bpmn2:targetRef>
         <bpmn2:assignment>
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA["PCM_EDIT"]]></bpmn2:from>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[PCM_FORM_EDIT]]></bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_9A946931-A84E-4FB7-A34B-EE83E177F938_pcmCodeInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
@@ -317,7 +317,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_wcIw4HiYEDuqG_XbBd_nDQ</bpmn2:source>
-    <bpmn2:target>_wcIw4HiYEDuqG_XbBd_nDQ</bpmn2:target>
+    <bpmn2:source>_3kohsHlVEDuSffuN8Xf_nw</bpmn2:source>
+    <bpmn2:target>_3kohsHlVEDuSffuN8Xf_nw</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_RpujYHnnEDujpfchrs0tnA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_7n840HnnEDujpfchrs0tnA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_pcmCodeItem" structureRef="String"/>
-  <bpmn2:itemDefinition id="_processJsonItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_processDataItem" structureRef="life.genny.qwandaq.graphql.ProcessData"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_pcmCodeOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputXItem" structureRef="String"/>
@@ -13,11 +13,12 @@
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_processDataOutputXItem" structureRef="String"/>
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.BaseEntityService" implementationRef="life.genny.kogito.common.service.BaseEntityService">
     <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="getEditPcmCode" implementationRef="getEditPcmCode"/>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_4CBC4F27-36E9-4ECF-8405-69BB5D8A8CAA" name="Default Collaboration">
-    <bpmn2:participant id="_64F49D93-564D-44B0-B0D7-8BE07632A6B9" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_4D8D21CB-C253-4409-998C-03DCBC2A4025" name="Default Collaboration">
+    <bpmn2:participant id="_B368AD11-5E86-4235-84D8-8F654E335941" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -25,12 +26,12 @@
     <bpmn2:property id="sourceCode" itemSubjectRef="_sourceCodeItem" name="sourceCode"/>
     <bpmn2:property id="targetCode" itemSubjectRef="_targetCodeItem" name="targetCode"/>
     <bpmn2:property id="pcmCode" itemSubjectRef="_pcmCodeItem" name="pcmCode"/>
-    <bpmn2:property id="processJson" itemSubjectRef="_processJsonItem" name="processJson"/>
+    <bpmn2:property id="processData" itemSubjectRef="_processDataItem" name="processData"/>
     <bpmn2:sequenceFlow id="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A"/>
     <bpmn2:sequenceFlow id="_7BB213A5-420C-4D89-AAA4-89B4CB0CB4E9" sourceRef="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" targetRef="_6B57FB09-0C73-46CA-92B3-5D158B176FD4"/>
     <bpmn2:sequenceFlow id="_9572DC60-677E-4D82-AB76-CAAF0FA0D1CE" sourceRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" targetRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B"/>
     <bpmn2:sequenceFlow id="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2" sourceRef="_321CE5F6-80DE-48BD-93F4-41E832A810FF" targetRef="_C26E7E06-BC61-4F28-836A-5AC72A0AFFC2"/>
-    <bpmn2:callActivity id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" drools:independent="false" drools:waitForCompletion="true" name="ProcessQuestions - Edit" calledElement="">
+    <bpmn2:callActivity id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" drools:independent="true" drools:waitForCompletion="true" name="ProcessQuestions - Edit" calledElement="processQuestions">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
           <drools:metaValue><![CDATA[ProcessQuestions - Edit]]></drools:metaValue>
@@ -45,6 +46,7 @@
         <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_pcmCodeInputXItem" name="pcmCode"/>
         <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputXItem" name="targetCode"/>
         <bpmn2:dataInput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputXItem" name="sourceCode"/>
+        <bpmn2:dataOutput id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_processDataOutputX" drools:dtype="String" itemSubjectRef="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_processDataOutputXItem" name="processData"/>
         <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_parentInputX</bpmn2:dataInputRefs>
@@ -53,6 +55,9 @@
           <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
+        <bpmn2:outputSet>
+          <bpmn2:dataOutputRefs>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_processDataOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
       </bpmn2:ioSpecification>
       <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputX</bpmn2:targetRef>
@@ -87,6 +92,10 @@
         <bpmn2:sourceRef>sourceCode</bpmn2:sourceRef>
         <bpmn2:targetRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation>
+        <bpmn2:sourceRef>_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_processDataOutputX</bpmn2:sourceRef>
+        <bpmn2:targetRef>processData</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
     </bpmn2:callActivity>
     <bpmn2:serviceTask id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" drools:serviceimplementation="Java" drools:serviceinterface="life.genny.kogito.common.service.BaseEntityService" drools:serviceoperation="getEditPcmCode" name="Find PCM Code" implementation="Java" operationRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation">
       <bpmn2:extensionElements>
@@ -155,7 +164,7 @@ kcontext.setVariable("targetCode", targetCode);
         <dc:Bounds height="102" width="154" x="554" y="215"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" bpmnElement="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A">
-        <dc:Bounds height="101" width="153" x="818.5" y="216"/>
+        <dc:Bounds height="101" width="153" x="820.5" y="215"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__321CE5F6-80DE-48BD-93F4-41E832A810FF_to_shape__C26E7E06-BC61-4F28-836A-5AC72A0AFFC2" bpmnElement="_9EAFFC1E-9D1F-449C-90C5-1E1E545291F2">
         <di:waypoint x="178" y="267"/>
@@ -166,12 +175,12 @@ kcontext.setVariable("targetCode", targetCode);
         <di:waypoint x="554" y="266"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_to_shape__6B57FB09-0C73-46CA-92B3-5D158B176FD4" bpmnElement="_7BB213A5-420C-4D89-AAA4-89B4CB0CB4E9">
-        <di:waypoint x="895" y="266.5"/>
+        <di:waypoint x="897" y="265.5"/>
         <di:waypoint x="1065" y="266.5"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9D02C26B-B836-4E7D-8898-B32157CC6F5B_to_shape__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" bpmnElement="_9F271F14-C9C3-409B-8B26-58A7BFD25BA1">
         <di:waypoint x="631" y="266"/>
-        <di:waypoint x="818.5" y="266.5"/>
+        <di:waypoint x="820.5" y="265.5"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
@@ -250,7 +259,7 @@ kcontext.setVariable("targetCode", targetCode);
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_RpujYHnnEDujpfchrs0tnA</bpmn2:source>
-    <bpmn2:target>_RpujYHnnEDujpfchrs0tnA</bpmn2:target>
+    <bpmn2:source>_7n840HnnEDujpfchrs0tnA</bpmn2:source>
+    <bpmn2:target>_7n840HnnEDujpfchrs0tnA</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -269,8 +269,14 @@ public class Dispatch {
 		// check for a question code
 		String questionCode = pcm.getValueAsString(Attribute.PRI_QUESTION_CODE);
 		if (questionCode == null) {
-			log.warn("Question Code is null for " + pcm.getCode());
-		} else if (!Question.QUE_EVENTS.equals(questionCode)) {
+			log.warn("Question Code is null for " + pcm.getCode() + ". Checking ProcessData");
+			questionCode = processData.getQuestionCode();
+			if(questionCode == null) {
+				log.warn("Question Code not set in ProcessData either");
+			}
+		}
+		
+		if (!Question.QUE_EVENTS.equals(questionCode)) {
 			// add ask to bulk message
 			Ask ask = qwandaUtils.generateAskFromQuestionCode(questionCode, source, target, userCapabilities, new ReqConfig());
 			msg.add(ask);

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -18,6 +18,7 @@ import javax.json.JsonObject;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import life.genny.kogito.common.service.TaskService;
@@ -276,7 +277,7 @@ public class Dispatch {
 			}
 		}
 		
-		if (!Question.QUE_EVENTS.equals(questionCode) && questionCode != null) {
+		if (!Question.QUE_EVENTS.equals(questionCode) && !StringUtils.isBlank(questionCode)) {
 			// add ask to bulk message
 			Ask ask = qwandaUtils.generateAskFromQuestionCode(questionCode, source, target, userCapabilities, new ReqConfig());
 			msg.add(ask);

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -276,7 +276,7 @@ public class Dispatch {
 			}
 		}
 		
-		if (!Question.QUE_EVENTS.equals(questionCode)) {
+		if (!Question.QUE_EVENTS.equals(questionCode) && questionCode != null) {
 			// add ask to bulk message
 			Ask ask = qwandaUtils.generateAskFromQuestionCode(questionCode, source, target, userCapabilities, new ReqConfig());
 			msg.add(ask);

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -178,6 +178,7 @@ public class BaseEntityService {
 		log.info("Setting questionCode of PCM: " + PCMCode + " to " + questionCode);
 		PCM pcm = beUtils.getPCM(questionCode);
 		pcm.setQuestionCode(PCMCode);
+		beUtils.updateBaseEntity(pcm);
 		
 		return pcm.getQuestionCode();
 	}

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -17,6 +17,7 @@ import life.genny.qwandaq.attribute.EntityAttribute;
 import life.genny.qwandaq.constants.Prefix;
 import life.genny.qwandaq.entity.BaseEntity;
 import life.genny.qwandaq.entity.Definition;
+import life.genny.qwandaq.entity.PCM;
 import life.genny.qwandaq.exception.runtime.DebugException;
 import life.genny.qwandaq.exception.runtime.NullParameterException;
 import life.genny.qwandaq.graphql.ProcessData;
@@ -167,6 +168,18 @@ public class BaseEntityService {
 		beUtils.updateBaseEntity(entity);
 	}
 
+	public String setPcmQuestionCode(String PCMCode, String questionCode) {
+		if(StringUtils.isBlank(PCMCode))
+			throw new NullParameterException("PCMCode");
+		if(StringUtils.isBlank(questionCode))
+			throw new NullParameterException("questionCode");
+
+		PCM pcm = beUtils.getPCM(PCM.PCM_FORM_EDIT);
+		pcm.setQuestionCode(questionCode);
+		
+		return pcm.getQuestionCode();
+	}
+
 	public String getDEFPrefix(String definitionCode) {
 
 		BaseEntity definition = beUtils.getBaseEntity(definitionCode);
@@ -181,14 +194,6 @@ public class BaseEntityService {
 
 	public String getBaseEntityQuestionGroup(String targetCode) {
 		return qwandaUtils.getEditQuestionGroups(targetCode)[0];
-		// BaseEntity target = beUtils.getBaseEntity(targetCode);
-		// BaseEntity definition = defUtils.getDEF(target);
-
-		// if (definition == null) {
-		// 	throw new NullParameterException("DEF:" + targetCode);
-		// }
-
-		// return CommonUtils.replacePrefix(definition.getCode(), "QUE");
 	}
 
 	/**

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -24,7 +24,6 @@ import life.genny.qwandaq.graphql.ProcessData;
 import life.genny.qwandaq.models.ServiceToken;
 import life.genny.qwandaq.models.UserToken;
 import life.genny.qwandaq.utils.BaseEntityUtils;
-import life.genny.qwandaq.utils.CommonUtils;
 import life.genny.qwandaq.utils.DefUtils;
 import life.genny.qwandaq.utils.KeycloakUtils;
 import life.genny.qwandaq.utils.QwandaUtils;
@@ -174,6 +173,7 @@ public class BaseEntityService {
 		if(StringUtils.isBlank(questionCode))
 			throw new NullParameterException("questionCode");
 
+		log.info("Setting questionCode of PCM: " + PCMCode + " to " + questionCode);
 		PCM pcm = beUtils.getPCM(PCM.PCM_FORM_EDIT);
 		pcm.setQuestionCode(questionCode);
 		

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -179,7 +179,7 @@ public class BaseEntityService {
 		final String buttonEvents = "SUBMIT,CANCEL,RESET"; // TODO: Multipage edits
 		final String parent = "PCM_CONTENT";
 		final String location = "PRI_LOC1";
-
+		log.debug("Sending edit with form code: " + pcmCode);
 	JsonObject payload = Json.createObjectBuilder()
 						.add("targetCode", targetCode)
 						.add("sourceCode", sourceCode)

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -178,7 +178,6 @@ public class BaseEntityService {
 		log.info("Setting questionCode of PCM: " + PCMCode + " to " + questionCode);
 		PCM pcm = beUtils.getPCM(questionCode);
 		pcm.setQuestionCode(PCMCode);
-		beUtils.updateBaseEntity(pcm);
 		
 		return pcm.getQuestionCode();
 	}

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -180,15 +180,15 @@ public class BaseEntityService {
 	}
 
 	public String getBaseEntityQuestionGroup(String targetCode) {
+		return qwandaUtils.getEditQuestionGroups(targetCode)[0];
+		// BaseEntity target = beUtils.getBaseEntity(targetCode);
+		// BaseEntity definition = defUtils.getDEF(target);
 
-		BaseEntity target = beUtils.getBaseEntity(targetCode);
-		BaseEntity definition = defUtils.getDEF(target);
+		// if (definition == null) {
+		// 	throw new NullParameterException("DEF:" + targetCode);
+		// }
 
-		if (definition == null) {
-			throw new NullParameterException("DEF:" + targetCode);
-		}
-
-		return CommonUtils.replacePrefix(definition.getCode(), "QUE");
+		// return CommonUtils.replacePrefix(definition.getCode(), "QUE");
 	}
 
 	/**

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -189,7 +189,7 @@ public class BaseEntityService {
 						.add("buttonEvents", buttonEvents)
 						.build();
 
-		kogitoUtils.triggerWorkflow(UseService.SELF, "edit", payload);
+		kogitoUtils.triggerWorkflow(UseService.SELF, "processQuestions", payload);
 	}
 
 	public String getDEFPrefix(String definitionCode) {

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -4,8 +4,6 @@ import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.json.Json;
-import javax.json.JsonObject;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
@@ -13,7 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import life.genny.kogito.common.utils.KogitoUtils;
-import life.genny.kogito.common.utils.KogitoUtils.UseService;
 import life.genny.qwandaq.Answer;
 import life.genny.qwandaq.EEntityStatus;
 import life.genny.qwandaq.attribute.Attribute;
@@ -21,7 +18,6 @@ import life.genny.qwandaq.attribute.EntityAttribute;
 import life.genny.qwandaq.constants.Prefix;
 import life.genny.qwandaq.entity.BaseEntity;
 import life.genny.qwandaq.entity.Definition;
-import life.genny.qwandaq.entity.PCM;
 import life.genny.qwandaq.exception.runtime.DebugException;
 import life.genny.qwandaq.exception.runtime.NullParameterException;
 import life.genny.qwandaq.graphql.ProcessData;
@@ -174,23 +170,25 @@ public class BaseEntityService {
 		beUtils.updateBaseEntity(entity);
 	}
 
-	public void edit(String questionCode, String sourceCode, String targetCode) {
-		final String pcmCode = qwandaUtils.getEditPcmCodes(targetCode)[0];
-		final String buttonEvents = "SUBMIT,CANCEL,RESET"; // TODO: Multipage edits
-		final String parent = "PCM_CONTENT";
-		final String location = "PRI_LOC1";
-		log.debug("Sending edit with form code: " + pcmCode);
-	JsonObject payload = Json.createObjectBuilder()
-						.add("targetCode", targetCode)
-						.add("sourceCode", sourceCode)
-						.add("pcmCode", pcmCode)
-						.add("parent", parent)
-						.add("location", location)
-						.add("buttonEvents", buttonEvents)
-						.build();
-
-		kogitoUtils.triggerWorkflow(UseService.SELF, "processQuestions", payload);
+	public String getEditPcmCode(String targetCode) {
+		return qwandaUtils.getEditPcmCodes(targetCode)[0];
 	}
+
+	// public void edit(String sourceCode, String targetCode) {
+	// 	final String pcmCode = qwandaUtils.getEditPcmCodes(targetCode)[0];
+	// 	final String buttonEvents = "SUBMIT,CANCEL,RESET"; // TODO: Multipage edits
+	// 	final String parent = "PCM_CONTENT";
+	// 	final String location = "PRI_LOC1";
+	// 	log.debug("Sending edit with form code: " + pcmCode);
+	// JsonObject payload = Json.createObjectBuilder()
+	// 					.add("targetCode", targetCode)
+	// 					.add("sourceCode", sourceCode)
+	// 					.add("pcmCode", pcmCode)
+	// 					.add("parent", parent)
+	// 					.add("location", location)
+	// 					.add("buttonEvents", buttonEvents)
+	// 					.build();
+	// }
 
 	public String getDEFPrefix(String definitionCode) {
 

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -167,6 +167,8 @@ public class BaseEntityService {
 		beUtils.updateBaseEntity(entity);
 	}
 
+	 // Honestly Kogito got me good on this one
+	 // TODO: Figure out why these need to be swapped
 	public String setPcmQuestionCode(String PCMCode, String questionCode) {
 		if(StringUtils.isBlank(PCMCode))
 			throw new NullParameterException("PCMCode");
@@ -174,8 +176,8 @@ public class BaseEntityService {
 			throw new NullParameterException("questionCode");
 
 		log.info("Setting questionCode of PCM: " + PCMCode + " to " + questionCode);
-		PCM pcm = beUtils.getPCM(PCM.PCM_FORM_EDIT);
-		pcm.setQuestionCode(questionCode);
+		PCM pcm = beUtils.getPCM(questionCode);
+		pcm.setQuestionCode(PCMCode);
 		
 		return pcm.getQuestionCode();
 	}

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -189,7 +189,7 @@ public class BaseEntityService {
 						.add("buttonEvents", buttonEvents)
 						.build();
 
-		kogitoUtils.triggerWorkflow(UseService.SELF, "messageLifecycle", payload);
+		kogitoUtils.triggerWorkflow(UseService.SELF, "edit", payload);
 	}
 
 	public String getDEFPrefix(String definitionCode) {

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -175,8 +175,8 @@ public class BaseEntityService {
 	}
 
 	public void edit(String questionCode, String sourceCode, String targetCode) {
-		final String pcmCode = "PCM_EDIT";
-		final String buttonEvents = "SUBMIT,CANCEL,RESET";
+		final String pcmCode = qwandaUtils.getEditPcmCodes(targetCode)[0];
+		final String buttonEvents = "SUBMIT,CANCEL,RESET"; // TODO: Multipage edits
 		final String parent = "PCM_CONTENT";
 		final String location = "PRI_LOC1";
 

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/utils/KogitoUtils.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/utils/KogitoUtils.java
@@ -74,8 +74,18 @@ public class KogitoUtils {
 	BaseEntityService baseEntityService;
 
 	public static enum UseService {
-		SELF,
-		GADAQ,
+		SELF(GennySettings.kogitoServiceUrl()),
+		GADAQ(GennySettings.gadaqServiceUrl());
+
+		private final String uri;
+
+		private UseService(String uri) {
+			this.uri = uri;
+		}
+
+		public String getServiceUrl() {
+			return uri;
+		}
 	}
 
 	/**
@@ -261,14 +271,7 @@ public class KogitoUtils {
 	 * @param useService The Service enum
 	 */
 	public String selectServiceURI(final UseService useService) {
-
-		switch (useService) {
-			case GADAQ:
-				return GennySettings.gadaqServiceUrl();
-			case SELF:
-			default:
-				return GennySettings.kogitoServiceUrl();
-		}
+		return useService.getServiceUrl();
 	}
 
 	/**

--- a/qwandaq/src/main/java/life/genny/qwandaq/attribute/Attribute.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/attribute/Attribute.java
@@ -166,6 +166,7 @@ public class Attribute extends CodedEntity {
 
 	// edit
 	public static final String LNK_EDIT_QUES = "LNK_EDIT_QUES";
+	public static final String LNK_EDIT_PCMS = "LNK_EDIT_PCMS";
 
 	@Embedded
 	@NotNull

--- a/qwandaq/src/main/java/life/genny/qwandaq/attribute/Attribute.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/attribute/Attribute.java
@@ -164,6 +164,9 @@ public class Attribute extends CodedEntity {
 	public static final String LNK_QUICK_SEARCH = "LNK_QUICK_SEARCH";
 	public static final String LNK_SAVED_SEARCH = "LNK_SAVED_SEARCH";
 
+	// edit
+	public static final String LNK_EDIT_QUES = "LNK_EDIT_QUES";
+
 	@Embedded
 	@NotNull
 	public DataType dataType;

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/PCM.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/PCM.java
@@ -39,6 +39,11 @@ public class PCM extends BaseEntity {
 	public static final String PCM_SBE_ADD_SEARCH = "PCM_SBE_ADD_SEARCH";
 	public static final String PCM_SBE_DETAIL_VIEW = "PCM_SBE_DETAIL_VIEW";
 
+
+	// edit
+	public static final String PCM_FORM_EDIT = "PCM_FORM_EDIT";
+	public static final String PCM_EDIT = "PCM_EDIT";
+
 	public PCM(String code, String name) {
 		super(code, name);
 	}

--- a/qwandaq/src/main/java/life/genny/qwandaq/intf/ICapabilityFilterable.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/intf/ICapabilityFilterable.java
@@ -11,7 +11,6 @@ import life.genny.qwandaq.datatype.capability.core.Capability;
 import life.genny.qwandaq.datatype.capability.core.CapabilitySet;
 import life.genny.qwandaq.datatype.capability.core.node.CapabilityNode;
 import life.genny.qwandaq.datatype.capability.requirement.ReqConfig;
-import life.genny.qwandaq.utils.CommonUtils;
 
 public interface ICapabilityFilterable {
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
@@ -603,11 +603,14 @@ public class BaseEntityUtils {
 				throw new DefinitionException("No prefix set for the def: " + definition.getCode());
 			}
 			if (StringUtils.isBlank(code)) {
-				code = prefix + "_" + UUID.randomUUID().toString().substring(0, 32).toUpperCase();
+				code = (prefix + "_" + UUID.randomUUID().toString().substring(0, 32)).toUpperCase();
 			}
 
 			log.info("Creating BE with code=" + code + ", name=" + name);
-			item = new BaseEntity(code.toUpperCase(), name);
+			if(StringUtils.isBlank(name)) {
+				name = code;
+			}
+			item = new BaseEntity(code, name);
 			item.setRealm(definition.getRealm());
 		}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
@@ -596,6 +596,7 @@ public class BaseEntityUtils {
 		Optional<EntityAttribute> uuidEA = definition.findEntityAttribute(Prefix.ATT.concat(Attribute.PRI_UUID));
 
 		if (uuidEA.isPresent()) {
+			log.debug("Creating user base entity");
 			item = createUser(definition);
 		} else {
 			String prefix = definition.getValueAsString(Attribute.PRI_PREFIX);
@@ -671,11 +672,11 @@ public class BaseEntityUtils {
 	 */
 	public BaseEntity createUser(final Definition definition) {
 
-		String email = "random+" + UUID.randomUUID().toString().substring(0, 20) + "@gada.io";
-
 		Optional<EntityAttribute> opt = definition.findEntityAttribute(Prefix.ATT.concat(Attribute.PRI_UUID));
 		if (opt.isEmpty())
 			throw new DefinitionException("Definition is not a User definition: " + definition.getCode());
+
+		String email = "random+" + UUID.randomUUID().toString().substring(0, 20) + "@gada.io";
 
 		// generate keycloak id
 		String uuid = KeycloakUtils.createDummyUser(serviceToken, userToken.getKeycloakRealm());

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
@@ -1,5 +1,6 @@
 package life.genny.qwandaq.utils;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -239,8 +240,23 @@ public class CommonUtils {
         return instance;
     }
 
-    public static <T> T[] getArrayFromString(String arrayString, FIGetObjectCallback<T> objectCallback) {
-        return (T[])getListFromString(arrayString, objectCallback).toArray();
+    @SuppressWarnings("unchecked")
+    public static <T> T[] getArrayFromString(String arrayString, Class<T> type, FIGetObjectCallback<T> objectCallback) {
+        arrayString = arrayString.substring(1, arrayString.length() - 1).replaceAll("\"", "").strip();
+        
+
+		if(StringUtils.isBlank(arrayString))
+            return (T[])Array.newInstance(type, 0);
+
+        String components[] = arrayString.split(",");
+        T[] array = (T[])Array.newInstance(type, components.length);
+                
+        for(int i = 0; i < components.length; i++) {
+            String component = components[i];
+            array[i] = objectCallback.getObject(component);
+        }
+
+        return array;
     }
 
     /**

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
@@ -349,15 +349,24 @@ public class CommonUtils {
 		return str.substring(str.indexOf("_")+1);
 	}
 
+    public static String substitutePrefix(String code, String prefix) {
+        if(prefix.length() == 4) {
+            if(prefix.charAt(3) != '_') {
+                log.error("Could not substitute prefix: " + prefix + ". Prefix length is not 3 characters or 4 characters including an '_'");
+                return code;
+            }
 
-	// TODO: Going to elaborate on this more another time. Will allow for the extra _ character some constants have
-	public static String substitutePrefix(String code, String prefix) {
+            // ensure 3 character length after underscore check
+            prefix = prefix.substring(0, 3);
+        }
+
 		if(prefix.length() != 3) {
-			log.error("Could not substitute prefix: " + prefix + ". Prefix length is not 3 characters");
+			log.error("Could not substitute prefix: " + prefix + ". Prefix length is not 3 characters or 4 characters including an '_'");
 			return code;
 		}
-		code = prefix + code.substring(prefix.length());
-		return code;
+
+        // all prefixes are now 3 characters at this point. Yay
+		return prefix.concat(code.substring(3));
 	}
 
 	/**

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
@@ -172,6 +172,19 @@ public class DefUtils {
 	}
 
 	/**
+	 * Find the corresponding definition for a given {@link BaseEntity} code.
+	 *
+	 * @param baseEntityCode The {@link BaseEntity} code to check
+	 * @return BaseEntity The corresponding definition {@link BaseEntity}
+	 */
+	public Definition getDEF(final String baseEntityCode) {
+		if(baseEntityCode == null)
+			throw new NullParameterException(baseEntityCode);
+		BaseEntity target = beUtils.getBaseEntity(baseEntityCode);
+		return getDEF(target);
+	}
+
+	/**
 	 * A function to determine the whether or not an attribute is allowed to be
 	 * saved to a {@link BaseEntity}.
 	 *

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -786,7 +786,7 @@ public class QwandaUtils {
 	 * @return Ask
 	 */
 	public Ask generateAskGroupUsingBaseEntity(BaseEntity baseEntity) {
-
+		new Exception("watch").printStackTrace();
 		// grab def entity
 		Definition definition = defUtils.getDEF(baseEntity);
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -886,7 +886,7 @@ public class QwandaUtils {
 		
 		String editQues = editQuesLnk.get().getValueString();
 		if(!StringUtils.isBlank(editQues))
-			return CommonUtils.getArrayFromString(editQues, (str) -> str);
+			return CommonUtils.getArrayFromString(editQues, String.class, (str) -> str);
 		
 		return new String[] {Question.QUE_BASEENTITY_GRP};
 	}

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -847,7 +847,7 @@ public class QwandaUtils {
 			throw new NullParameterException("baseEntityCode");
 		// ensure def
 		log.info("[!] Attempting to retrieve edit question groups from base entity: " + baseEntityCode);
-		Definition baseEntity = beUtils.getDefinition(baseEntityCode);
+		Definition baseEntity = defUtils.getDEF(baseEntityCode);
 		if(baseEntity == null) {
 			log.error("Could not find Definition of be: " + baseEntityCode);
 		} else {

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -887,8 +887,10 @@ public class QwandaUtils {
 		log.debug("FOUND LNK_EDIT_QUES");
 
 		String editQues = editQuesLnk.get().getValueString();
-		if(!StringUtils.isBlank(editQues))
+		if(!StringUtils.isBlank(editQues)) {
+			log.info("Found edit questions: " + editQues);
 			return CommonUtils.getArrayFromString(editQues, String.class, (str) -> str);
+		}
 		
 		log.warn("Edit ques was blank. Defaulting to QUE_BASEENTITY_GRP");
 		return new String[] {Question.QUE_BASEENTITY_GRP};

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -884,9 +884,6 @@ public class QwandaUtils {
 		Optional<EntityAttribute> editQuesLnk = baseEntity.findEntityAttribute(Attribute.LNK_EDIT_PCMS);
 		if(!editQuesLnk.isPresent()) {
 			log.warn("Could not find LNK_EDIT_PCMS in " + baseEntity.getCode() + ". Defaulting to PCM_FORM_EDIT");
-			CommonUtils.printCollection(baseEntity.getBaseEntityAttributes(), log::debug, (ea) -> {
-				return "	" + ea.getBaseEntityCode() + ":" + ea.getAttributeCode() + " = " + ea.getValueString();
-			});
 			return new String[] {"PCM_FORM_EDIT"};
 		}
 		
@@ -923,9 +920,6 @@ public class QwandaUtils {
 		Optional<EntityAttribute> editQuesLnk = baseEntity.findEntityAttribute(Attribute.LNK_EDIT_QUES);
 		if(!editQuesLnk.isPresent()) {
 			log.warn("Could not find LNK_EDIT_QUES in " + baseEntity.getCode() + ". Defaulting to QUE_BASEENTITY_GRP");
-			CommonUtils.printCollection(baseEntity.getBaseEntityAttributes(), log::debug, (ea) -> {
-				return "	" + ea.getBaseEntityCode() + ":" + ea.getAttributeCode() + " = " + ea.getValueString();
-			});
 			return new String[] {Question.QUE_BASEENTITY_GRP};
 		}
 		

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -884,10 +884,13 @@ public class QwandaUtils {
 			return new String[] {Question.QUE_BASEENTITY_GRP};
 		}
 		
+		log.debug("FOUND LNK_EDIT_QUES");
+
 		String editQues = editQuesLnk.get().getValueString();
 		if(!StringUtils.isBlank(editQues))
 			return CommonUtils.getArrayFromString(editQues, String.class, (str) -> str);
 		
+		log.warn("Edit ques was blank. Defaulting to QUE_BASEENTITY_GRP");
 		return new String[] {Question.QUE_BASEENTITY_GRP};
 	}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -860,7 +860,7 @@ public class QwandaUtils {
 		if(targetCode == null)
 			throw new NullParameterException("targetCode");
 		// ensure def
-		log.info("[!] Attempting to retrieve edit question groups from base entity: " + targetCode);
+		log.info("[!] Attempting to retrieve edit pcms from base entity: " + targetCode);
 		Definition baseEntity = defUtils.getDEF(targetCode);
 		if(baseEntity == null) {
 			log.error("Could not find Definition of be: " + targetCode);

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -878,6 +878,9 @@ public class QwandaUtils {
 		Optional<EntityAttribute> editQuesLnk = baseEntity.findEntityAttribute(Attribute.LNK_EDIT_QUES);
 		if(!editQuesLnk.isPresent()) {
 			log.warn("Could not find LNK_EDIT_QUES in " + baseEntity.getCode() + ". Defaulting to QUE_BASEENTITY_GRP");
+			CommonUtils.printCollection(baseEntity.getBaseEntityAttributes(), log::debug, (ea) -> {
+				return "	" + ea.getBaseEntityCode() + ":" + ea.getAttributeCode() + " = " + ea.getValueString();
+			});
 			return new String[] {Question.QUE_BASEENTITY_GRP};
 		}
 		

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -786,7 +786,6 @@ public class QwandaUtils {
 	 * @return Ask
 	 */
 	public Ask generateAskGroupUsingBaseEntity(BaseEntity baseEntity) {
-		new Exception("watch").printStackTrace();
 		// grab def entity
 		Definition definition = defUtils.getDEF(baseEntity);
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -847,6 +847,7 @@ public class QwandaUtils {
 			throw new NullParameterException("baseEntityCode");
 		// ensure def
 		baseEntityCode = CommonUtils.substitutePrefix(baseEntityCode, Prefix.DEF);
+		log.info("[!] Attempting to retrieve edit question groups from base entity: " + baseEntityCode);
 		BaseEntity baseEntity = beUtils.getDefinition(baseEntityCode);
 
 		return getEditQuestionGroups(baseEntity);
@@ -871,8 +872,10 @@ public class QwandaUtils {
 
 		// Look for attached edit ques. If none then default to QUE_BASEENTITY_GRP
 		Optional<EntityAttribute> editQuesLnk = baseEntity.findEntityAttribute(Attribute.LNK_EDIT_QUES);
-		if(!editQuesLnk.isPresent())
+		if(!editQuesLnk.isPresent()) {
+			log.warn("Could not find LNK_EDIT_QUES in " + baseEntity.getCode() + ". Defaulting to QUE_BASEENTITY_GRP");
 			return new String[] {Question.QUE_BASEENTITY_GRP};
+		}
 		
 		String editQues = editQuesLnk.get().getValueString();
 		if(!StringUtils.isBlank(editQues))

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -846,9 +846,13 @@ public class QwandaUtils {
 		if(baseEntityCode == null)
 			throw new NullParameterException("baseEntityCode");
 		// ensure def
-		baseEntityCode = CommonUtils.substitutePrefix(baseEntityCode, Prefix.DEF);
 		log.info("[!] Attempting to retrieve edit question groups from base entity: " + baseEntityCode);
-		BaseEntity baseEntity = beUtils.getDefinition(baseEntityCode);
+		Definition baseEntity = beUtils.getDefinition(baseEntityCode);
+		if(baseEntity == null) {
+			log.error("Could not find Definition of be: " + baseEntityCode);
+		} else {
+			log.info("Found: " + baseEntity.getCode());
+		}
 
 		return getEditQuestionGroups(baseEntity);
 	}


### PR DESCRIPTION
supply custom pcm forms in a definition to edit base entities. If no pcm is supplied, it will default to PCM_FORM_EDIT and use QUE_BASEENTITY_GRP to generate question groups. If necessary I can bring across the old code that filtered QUE_BASEENTITY_GRP, but this will work for now.

Example link of a pcm form to a definition: DEF_XXX:LNK_EDIT_PCMS =["PCM_FORM_1_XXX", "PCM_FORM_2_XXX", "SOME_OTHER_PCM"]

Call edit flow with userCode, sourceCode, targetCode as arguments. Automatically called when gadaq/Events.java receives event with code "ACT_EDIT". Currently only applies for messages with SBEs as parents but can be expanded if necessary