### PR TITLE
Prefix Renaming & Remove Dpct Methods

### DIFF
--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/cache/SearchCaching.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/cache/SearchCaching.java
@@ -101,7 +101,7 @@ public class SearchCaching {
 		// DEF_MESSAGE
 		cacheSearch(
 				new SearchEntity(SBE_MESSAGE, "Messages")
-						.add(new Filter(PRI_CODE, Operator.STARTS_WITH, Prefix.MSG))
+						.add(new Filter(PRI_CODE, Operator.STARTS_WITH, Prefix.MSG_))
 						.add(new Column(PRI_NAME, "Code"))
 						.add(new Column(PRI_DESCRIPTION, "Description"))
 						.add(new Column(PRI_DEFAULT_MSG_TYPE, "Default Message Type"))

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -170,7 +170,7 @@ public class Events {
 		// add item
 		if (code.startsWith(QUE_ADD_)) {
 			code = StringUtils.removeStart(code, QUE_ADD_);
-			String prefix = CacheUtils.getObject(userToken.getProductCode(), Prefix.DEF + code + ":PREFIX", String.class);
+			String prefix = CacheUtils.getObject(userToken.getProductCode(), Prefix.DEF_ + code + ":PREFIX", String.class);
 
 			JsonObject json = Json.createObjectBuilder()
 			.add("definitionCode", "DEF_".concat(code))

--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/search/FilterGroupService.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/search/FilterGroupService.java
@@ -105,7 +105,7 @@ public class FilterGroupService {
      */
     public  boolean isValidTable(String code) {
         boolean result = false;
-        if(code!=null &&  code.startsWith(Prefix.QUE_TABLE_PREF)) return true;
+        if(code!=null &&  code.startsWith(Prefix.QUE_TABLE_)) return true;
         return result;
     }
 
@@ -208,7 +208,7 @@ public class FilterGroupService {
      */
     public String getColumnName(String value) {
         String lastSuffix = "";
-        int lastIndex = value.lastIndexOf(Prefix.PRI) + Prefix.PRI.length();
+        int lastIndex = value.lastIndexOf(Prefix.PRI_) + Prefix.PRI_.length();
         if(lastIndex > -1) {
             lastSuffix = value.substring(lastIndex, value.length());
             lastSuffix = lastSuffix.replaceFirst("\"]","");
@@ -488,7 +488,7 @@ public class FilterGroupService {
             // create the main base entity
             String attCode = Attribute.LNK_SAVED_SEARCHES;
             Attribute attr = new Attribute(PRI_PREFIX, attCode, DataTypeStr);
-            defBE.addAttribute(attr, 1.0, Prefix.SBE);
+            defBE.addAttribute(attr, 1.0, Prefix.SBE_);
             if(nameOrCode.startsWith(SearchEntity.SBE_SAVED_SEARCH)) {
                 baseEntity = beUtils.getBaseEntity(userToken.getProductCode(), nameOrCode);
             } else {

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -265,7 +265,7 @@ public class Dispatch {
 		}
 
 		// iterate locations
-		List<EntityAttribute> locations = pcm.findPrefixEntityAttributes(Prefix.LOCATION);
+		List<EntityAttribute> locations = pcm.findPrefixEntityAttributes(Prefix.PRI_LOC);
 		List<EntityAttribute> filteredLocations = new ArrayList<>(locations.size());
 		for (EntityAttribute entityAttribute : locations) {
 			if(!entityAttribute.requirementsMet(userCapabilities)) {
@@ -278,11 +278,11 @@ public class Dispatch {
 			
 			// recursively check PCM fields
 			String value = entityAttribute.getAsString();
-			if (value.startsWith(Prefix.PCM)) {
+			if (value.startsWith(Prefix.PCM_)) {
 				parent = pcm.getCode();
 				location = entityAttribute.getAttributeCode();
 				traversePCM(userCapabilities, value, source, target, parent, location, msg, processData);
-			} else if (value.startsWith(Prefix.SBE)) {
+			} else if (value.startsWith(Prefix.SBE_)) {
 				processData.getSearches().add(value);
 			}
 		}
@@ -340,7 +340,7 @@ public class Dispatch {
 			String code = name.toUpperCase().replaceAll(" ", "_");
 			// create child and add to ask
 			Attribute attribute = qwandaUtils.createButtonEvent(code, name);
-			Question question = new Question(Prefix.QUE + code, name, attribute);
+			Question question = new Question(Prefix.QUE_ + code, name, attribute);
 			Ask child = new Ask(question, sourceCode, targetCode);
 			ask.add(child);
 		}
@@ -389,7 +389,7 @@ public class Dispatch {
 		}
 
 		// check for dropdown attribute
-		if (ask.getQuestion().getAttribute().getCode().startsWith(Prefix.LNK)) {
+		if (ask.getQuestion().getAttribute().getCode().startsWith(Prefix.LNK_)) {
 
 			// get list of value codes
 			List<String> codes = beUtils.getBaseEntityCodeArrayFromLinkAttribute(target,
@@ -437,7 +437,7 @@ public class Dispatch {
 		Question question = ask.getQuestion();
 		Attribute attribute = question.getAttribute();
 
-		if (attribute.getCode().startsWith(Prefix.LNK)) {
+		if (attribute.getCode().startsWith(Prefix.LNK_)) {
 
 			// check for already selected items
 			List<String> codes = beUtils.getBaseEntityCodeArrayFromLinkAttribute(target, attribute.getCode());
@@ -515,7 +515,7 @@ public class Dispatch {
 		Attribute priName = qwandaUtils.getAttribute(Attribute.PRI_NAME);
 
 		baseEntities.stream()
-			.filter(b -> !b.getCode().startsWith(Prefix.QBE))
+			.filter(b -> !b.getCode().startsWith(Prefix.QBE_))
 			.forEach(entity -> {
 			entity.addAttribute(new EntityAttribute(entity, priName, 1.0, entity.getName()));
 			MergeUtils.mergeBaseEntity(entity, contexts);

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/messages/SendAllMessages.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/messages/SendAllMessages.java
@@ -83,7 +83,7 @@ public class SendAllMessages extends MessageSendingStrategy {
             log.info("messages : " + messageCodes.size());
             messageCodes.parallelStream().forEach((messageCode) -> {
                 log.info("messageCode : " + messageCode);
-                BaseEntity message = beUtils.getBaseEntityByCode(messageCode);
+                BaseEntity message = beUtils.getBaseEntity(messageCode);
 
                 // Determine the recipientBECode
                 String recipientLnkValue = message.getValueAsString(PRI_RECIPIENT_LNK);
@@ -94,7 +94,7 @@ public class SendAllMessages extends MessageSendingStrategy {
                 }
 
                 // Extract all the contexts from the core baseEntity LNKs
-                List<EntityAttribute> lnkEAs = coreBE.findPrefixEntityAttributes("LNK");
+                List<EntityAttribute> lnkEAs = coreBE.findPrefixEntityAttributes(Prefix.LNK_);
                 StringBuilder contextMapStr = new StringBuilder();
 
                 lnkEAs.parallelStream().forEach((ea) -> {
@@ -131,7 +131,7 @@ public class SendAllMessages extends MessageSendingStrategy {
             if (recipientLnkValue.startsWith(SELF)) { // The coreBE is the recipient
                 ctxMap.put(RECIPIENT, coreBE.getCode());
                 recipientBECode = coreBE.getCode();
-            } else if (recipientLnkValue.startsWith(Prefix.PER)) {
+            } else if (recipientLnkValue.startsWith(Prefix.PER_)) {
                 ctxMap.put(RECIPIENT, recipientLnkValue);
                 recipientBECode = recipientLnkValue;
             } else {
@@ -154,7 +154,7 @@ public class SendAllMessages extends MessageSendingStrategy {
             // check the various formats to get the senderBECode
             if (senderLnkValue.startsWith(USER)) { // The user is the sender
                 ctxMap.put(SENDER, userToken.getUserCode());
-            } else if (senderLnkValue.startsWith(Prefix.PER)) {
+            } else if (senderLnkValue.startsWith(Prefix.PER_)) {
                 ctxMap.put(SENDER, senderLnkValue);
             } else {
                 // check if it is a LNK path (of the coreBE)

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/messages/SendMessage.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/messages/SendMessage.java
@@ -21,7 +21,7 @@ public class SendMessage extends MessageSendingStrategy {
     public SendMessage(String templateCode, String recipientBECode) {
         super();
         this.templateCode = templateCode;
-        this.recipientBE = beUtils.getBaseEntityByCode(recipientBECode);
+        this.recipientBE = beUtils.getBaseEntity(recipientBECode);
     }
 
     public SendMessage(String templateCode, String recipientBECode, Map<String, String> ctxMap) {
@@ -30,7 +30,7 @@ public class SendMessage extends MessageSendingStrategy {
         if (beUtils == null) {
             log.warn("beUtils is NULL --> no userToken");
         }
-        this.recipientBE = beUtils.getBaseEntityByCode(recipientBECode);
+        this.recipientBE = beUtils.getBaseEntity(recipientBECode);
         this.ctxMap = ctxMap;
     }
 

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/BaseEntityService.java
@@ -70,7 +70,7 @@ public class BaseEntityService {
 
 		if (definitionCode == null)
 			throw new NullParameterException("definitionCode");
-		if (!definitionCode.startsWith(Prefix.DEF))
+		if (!definitionCode.startsWith(Prefix.DEF_))
 			throw new DebugException("Invalid definitionCode: " + definitionCode);
 
 		// fetch the def baseentity

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/FilterService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/FilterService.java
@@ -196,7 +196,7 @@ public class FilterService {
 
         CacheUtils.putObject(userToken.getProductCode(), cachedKey, searchBE);
 
-        String queCode =  targetCode.replaceFirst(Prefix.SBE,Prefix.QUE);
+        String queCode =  targetCode.replaceFirst(Prefix.SBE_,Prefix.QUE_);
         search.sendTable(queCode);
 
     }
@@ -235,7 +235,7 @@ public class FilterService {
 
         CacheUtils.putObject(userToken.getProductCode(), cachedKey, searchBE);
 
-        String queCode =  targetCode.replaceFirst(Prefix.SBE,Prefix.QUE);
+        String queCode =  targetCode.replaceFirst(Prefix.SBE_,Prefix.QUE_);
         search.sendTable(queCode);
     }
 
@@ -389,7 +389,7 @@ public class FilterService {
 
         CacheUtils.putObject(userToken.getProductCode(), cachedKey, searchBE);
 
-        String queCode =  sbeCode.replaceFirst(Prefix.SBE,Prefix.QUE);
+        String queCode =  sbeCode.replaceFirst(Prefix.SBE_,Prefix.QUE_);
         search.sendTable(queCode);
     }
 
@@ -537,28 +537,28 @@ public class FilterService {
      * @return Get Search filter by filter value
      */
     public Operator getOperatorByVal(String filterVal){
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_GREATER_THAN.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_GREATER_THAN.replaceFirst(Prefix.SEL_,""))){
             return Operator.GREATER_THAN;
         }
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_GREATER_THAN_OR_EQUAL_TO.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_GREATER_THAN_OR_EQUAL_TO.replaceFirst(Prefix.SEL_,""))){
             return Operator.GREATER_THAN_OR_EQUAL;
         }
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_LESS_THAN.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_LESS_THAN.replaceFirst(Prefix.SEL_,""))){
             return Operator.LESS_THAN;
         }
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_LESS_THAN_OR_EQUAL_TO.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_LESS_THAN_OR_EQUAL_TO.replaceFirst(Prefix.SEL_,""))){
             return Operator.LESS_THAN_OR_EQUAL;
         }
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_EQUAL_TO.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_EQUAL_TO.replaceFirst(Prefix.SEL_,""))){
             return Operator.EQUALS;
         }
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_NOT_EQUAL_TO.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_NOT_EQUAL_TO.replaceFirst(Prefix.SEL_,""))){
             return Operator.NOT_EQUALS;
         }
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_LIKE.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_LIKE.replaceFirst(Prefix.SEL_,""))){
             return Operator.LIKE;
         }
-        if(filterVal.equalsIgnoreCase(FilterConst.SEL_NOT_LIKE.replaceFirst(Prefix.SEL,""))){
+        if(filterVal.equalsIgnoreCase(FilterConst.SEL_NOT_LIKE.replaceFirst(Prefix.SEL_,""))){
             return Operator.NOT_LIKE;
         }
 
@@ -711,8 +711,8 @@ public class FilterService {
             valBuild.append(FilterConst.SEPARATOR+ss.getValueCode());
 
             StringBuilder lblBuild = new StringBuilder(att.getName() + FilterConst.SEPARATOR);
-            lblBuild.append(ss.getOperator().replaceFirst(Prefix.SEL, "").replaceAll("_"," "));
-            lblBuild.append(FilterConst.SEPARATOR + ss.getValue().replaceFirst(Prefix.SEL, ""));
+            lblBuild.append(ss.getOperator().replaceFirst(Prefix.SEL_, "").replaceAll("_"," "));
+            lblBuild.append(FilterConst.SEPARATOR + ss.getValue().replaceFirst(Prefix.SEL_, ""));
 
             EntityAttribute ea = new EntityAttribute(base, att, 1.0);
             ea.setAttributeName(lblBuild.toString());
@@ -826,7 +826,7 @@ public class FilterService {
      */
     public void init(String queCode) {
         clearParamsInCache();
-        String sbe = queCode.replaceFirst(Prefix.QUE,Prefix.SBE);
+        String sbe = queCode.replaceFirst(Prefix.QUE_,Prefix.SBE_);
         sendFilterColumns(sbe);
         CacheUtils.putObject(userToken.getProductCode(),getCachedSbeTable(), sbe);
 
@@ -1020,10 +1020,10 @@ public class FilterService {
     public void addDefinitionCodeByBucket(List<String> definitions) {
         PCM pcm = beUtils.getPCM(PCM.PCM_PROCESS);
 
-        List<EntityAttribute> locations = pcm.findPrefixEntityAttributes(Prefix.LOCATION);
+        List<EntityAttribute> locations = pcm.findPrefixEntityAttributes(Prefix.PRI_LOC);
         for (EntityAttribute entityAttribute : locations) {
             String value = entityAttribute.getAsString();
-            if (value.startsWith(Prefix.SBE)) {
+            if (value.startsWith(Prefix.SBE_)) {
                 String defCode = getDefinitionCode(value);
                 if(!defCode.isEmpty()) {
                     definitions.add(defCode);

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/GennyService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/GennyService.java
@@ -55,7 +55,7 @@ public class GennyService {
 
 		CommonUtils.getArcInstance(BaseEntityUtils.class);
 
-		BaseEntity be = beUtils.getBaseEntityOrNull(code);
+		BaseEntity be = beUtils.getBaseEntity(code);
 
 		if (be == null) {
 			log.error("BaseEntity not found");
@@ -81,7 +81,7 @@ public class GennyService {
 		log.info("Source Code = " + userToken.getUserCode());
 		log.info("BaseEntity Code = " + code);
 
-		BaseEntity be = beUtils.getBaseEntityOrNull(code);
+		BaseEntity be = beUtils.getBaseEntity(code);
 
 		if (be == null) {
 			log.error("BaseEntity not found");
@@ -110,7 +110,7 @@ public class GennyService {
 		log.info("BaseEntity Code = " + code);
 
 		beUtils = new BaseEntityUtils(serviceToken); // assume userToken dead.
-		BaseEntity be = beUtils.getBaseEntityOrNull(code);
+		BaseEntity be = beUtils.getBaseEntity(code);
 
 		if (be == null) {
 			log.error("BaseEntity not found");
@@ -136,7 +136,7 @@ public class GennyService {
 		log.info("BaseEntity Code = " + code);
 
 		beUtils = new BaseEntityUtils(serviceToken); // assume userToken dead.
-		BaseEntity be = beUtils.getBaseEntityOrNull(code);
+		BaseEntity be = beUtils.getBaseEntity(code);
 
 		if (be == null) {
 			log.error("BaseEntity not found");
@@ -160,7 +160,7 @@ public class GennyService {
 		log.info("BaseEntity Code = " + code);
 
 		beUtils = new BaseEntityUtils(serviceToken); // assume userToken dead.
-		BaseEntity baseEntity = beUtils.getBaseEntityOrNull(code);
+		BaseEntity baseEntity = beUtils.getBaseEntity(code);
 
 		if (baseEntity == null) {
 			log.error("BaseEntity not found");

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/InitService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/InitService.java
@@ -1,7 +1,6 @@
 package life.genny.kogito.common.service;
 
 import java.util.Arrays;
-import java.util.List;
 
 import java.util.stream.Collectors;
 
@@ -14,15 +13,11 @@ import org.jboss.logging.Logger;
 
 import life.genny.qwandaq.Ask;
 
-import life.genny.qwandaq.Question;
 import life.genny.qwandaq.attribute.Attribute;
 import life.genny.qwandaq.constants.Prefix;
 import life.genny.qwandaq.datatype.capability.core.CapabilitySet;
 import life.genny.qwandaq.datatype.capability.requirement.ReqConfig;
 import life.genny.qwandaq.entity.BaseEntity;
-import life.genny.qwandaq.entity.search.SearchEntity;
-import life.genny.qwandaq.entity.search.trait.Filter;
-import life.genny.qwandaq.entity.search.trait.Operator;
 
 import life.genny.qwandaq.kafka.KafkaTopic;
 import life.genny.qwandaq.managers.capabilities.CapabilitiesManager;
@@ -32,7 +27,6 @@ import life.genny.qwandaq.message.QDataBaseEntityMessage;
 import life.genny.qwandaq.models.UserToken;
 import life.genny.qwandaq.utils.BaseEntityUtils;
 import life.genny.qwandaq.utils.CacheUtils;
-import life.genny.qwandaq.utils.CommonUtils;
 import life.genny.qwandaq.utils.DatabaseUtils;
 
 import life.genny.qwandaq.utils.KafkaUtils;
@@ -119,7 +113,7 @@ public class InitService {
 
 			Attribute[] attributes = Arrays.asList(msg.getItems()).stream()
 				// Filter capability attributes
-				.filter((attribute) -> !attribute.getCode().startsWith(Prefix.CAP))
+				.filter((attribute) -> !attribute.getCode().startsWith(Prefix.CAP_))
 				.collect(Collectors.toList())
 				.toArray(new Attribute[0]);
 

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/SearchService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/SearchService.java
@@ -86,7 +86,7 @@ public class SearchService {
 	 */
 	public void sendTable(String code) {
 
-		code = StringUtils.replaceOnce(code, Prefix.QUE, Prefix.PCM);
+		code = StringUtils.replaceOnce(code, Prefix.QUE_, Prefix.PCM_);
 		log.info("Sending Table :: " + code);
 
 		String userCode = userToken.getUserCode();
@@ -111,10 +111,10 @@ public class SearchService {
 		// fetch target and find it's definition
 		BaseEntity target = beUtils.getBaseEntity(targetCode);
 		BaseEntity definition = defUtils.getDEF(target);
-		String type = StringUtils.removeStart(definition.getCode(), Prefix.DEF);
+		String type = StringUtils.removeStart(definition.getCode(), Prefix.DEF_);
 
 		// construct template and question codes from type
-		String pcmCode = new StringBuilder(Prefix.PCM).append(type).append("_DETAIL_VIEW").toString();
+		String pcmCode = new StringBuilder(Prefix.PCM_).append(type).append("_DETAIL_VIEW").toString();
 
 		// send pcm with correct info
 		String userCode = userToken.getUserCode();

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/Service2Service.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/Service2Service.java
@@ -59,7 +59,7 @@ public class Service2Service {
 			// We need to fetch the latest token for the sourceUser
 			log.debug(taskExchange.getSourceCode() + " : No token found, fetching latest token");
 			BaseEntity userBE = beUtils.getBaseEntity(taskExchange.getSourceCode());
-			BaseEntity project = beUtils.getBaseEntity(Prefix.PRJ.concat("_".concat(userBE.getRealm().toUpperCase())));
+			BaseEntity project = beUtils.getBaseEntity(Prefix.PRJ_.concat("_".concat(userBE.getRealm().toUpperCase())));
 			userToken = new UserToken(KeycloakUtils.getImpersonatedToken(userBE, serviceToken, project));
 		}
 		logToken();

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/Service2Service.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/Service2Service.java
@@ -59,7 +59,7 @@ public class Service2Service {
 			// We need to fetch the latest token for the sourceUser
 			log.debug(taskExchange.getSourceCode() + " : No token found, fetching latest token");
 			BaseEntity userBE = beUtils.getBaseEntity(taskExchange.getSourceCode());
-			BaseEntity project = beUtils.getBaseEntity(Prefix.PRJ_.concat("_".concat(userBE.getRealm().toUpperCase())));
+			BaseEntity project = beUtils.getBaseEntity(Prefix.PRJ_.concat(userBE.getRealm().toUpperCase()));
 			userToken = new UserToken(KeycloakUtils.getImpersonatedToken(userBE, serviceToken, project));
 		}
 		logToken();

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/TaskService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/TaskService.java
@@ -129,7 +129,7 @@ public class TaskService {
 		processData.setProcessId(processId);
 		processData.setAnswers(new ArrayList<>());
 
-		String processEntityCode = Prefix.QBE.concat(targetCode.substring(4));
+		String processEntityCode = Prefix.QBE_.concat(targetCode.substring(4));
 		processData.setProcessEntityCode(processEntityCode);
 
 		String userCode = userToken != null ? userToken.getUserCode() : null;

--- a/lauchy/src/main/java/life/genny/lauchy/Validator.java
+++ b/lauchy/src/main/java/life/genny/lauchy/Validator.java
@@ -66,7 +66,7 @@ public class Validator {
 		List<Ask> asksToSend = new ArrayList<>();
 
 		Arrays.stream(answers.getItems())
-				.filter(answer -> answer.getAttributeCode() != null && answer.getAttributeCode().startsWith(Prefix.LNK))
+				.filter(answer -> answer.getAttributeCode() != null && answer.getAttributeCode().startsWith(Prefix.LNK_))
 				.forEach(answer -> {
 					String processId = answer.getProcessId();
 					// TODO: Wondering if we can just get the processData from the first processId
@@ -184,7 +184,7 @@ public class Validator {
 			log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
 
 			// check attribute code is allowed by target DEF
-			if (!definition.containsEntityAttribute(Prefix.ATT + attributeCode)) {
+			if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
 				log.warn("AttributeCode " + attributeCode + " not allowed for " + definition.getCode());
 				notValidForAnyDefinition = true;
 			}

--- a/messages/src/main/java/life/genny/messages/managers/QEmailMessageManager.java
+++ b/messages/src/main/java/life/genny/messages/managers/QEmailMessageManager.java
@@ -33,7 +33,7 @@ public final class QEmailMessageManager extends QMessageProvider {
 		BaseEntity recipientBe = (BaseEntity) contextMap.get("RECIPIENT");
 		BaseEntity projectBe = (BaseEntity) contextMap.get("PROJECT");
 
-		recipientBe = beUtils.getBaseEntityOrNull(recipientBe.getCode());
+		recipientBe = beUtils.getBaseEntity(recipientBe.getCode());
 
 		if (templateBe == null) {
 			throw new NullParameterException("templateBe");

--- a/messages/src/main/java/life/genny/messages/managers/QSendGridMessageManager.java
+++ b/messages/src/main/java/life/genny/messages/managers/QSendGridMessageManager.java
@@ -39,7 +39,7 @@ public final class QSendGridMessageManager extends QMessageProvider {
 		BaseEntity recipientBe = (BaseEntity) contextMap.get("RECIPIENT");
 		BaseEntity projectBe = (BaseEntity) contextMap.get("PROJECT");
 		
-		recipientBe = beUtils.getBaseEntityOrNull(recipientBe.getCode());
+		recipientBe = beUtils.getBaseEntity(recipientBe.getCode());
 
 		if (templateBe == null) {
 			throw new NullParameterException("templateBe");

--- a/messages/src/main/java/life/genny/messages/process/MessageProcessor.java
+++ b/messages/src/main/java/life/genny/messages/process/MessageProcessor.java
@@ -76,7 +76,7 @@ public class MessageProcessor {
 
         log.debug("Realm is " + realm + " - Incoming Message :: " + message.toString());
 
-        BaseEntity projectBe = beUtils.getBaseEntityByCode("PRJ_" + realm.toUpperCase());
+        BaseEntity projectBe = beUtils.getBaseEntity("PRJ_" + realm.toUpperCase());
 
         // try {
         //     log.warn("*** HORRIBLE ACC HACK TO DELAY FOR 10 SEC TO ALLOW CACHE ITEM TO BE COMPLETE");
@@ -90,7 +90,7 @@ public class MessageProcessor {
 
         BaseEntity templateBe = null;
         if (message.getTemplateCode() != null) {
-            templateBe = beUtils.getBaseEntityByCode(message.getTemplateCode());
+            templateBe = beUtils.getBaseEntity(message.getTemplateCode());
         }
 
         if (templateBe != null) {
@@ -232,7 +232,7 @@ public class MessageProcessor {
     private void sendToProvider(QMessageGennyMSG message, Map<String, Object> baseEntityContextMap, 
                     BaseEntity templateBe, BaseEntity recipientBe, List<QBaseMSGMessageType> messageTypeList) {
         final String templateCode = message.getTemplateCode() + "_UNSUBSCRIBE";
-        final BaseEntity unsubscriptionBe = beUtils.getBaseEntityByCode("COM_EMAIL_UNSUBSCRIPTION");
+        final BaseEntity unsubscriptionBe = beUtils.getBaseEntity("COM_EMAIL_UNSUBSCRIPTION");
         if(unsubscriptionBe == null) {
             log.warn("Unsubscription Base Entity is null! All users will be treated at subscribed");
         }
@@ -289,7 +289,7 @@ public class MessageProcessor {
                     log.info("Fetching contextCodeArray :: " + Arrays.toString(codeArr));
                     // Convert to BEs
                     BaseEntity[] beArray = Arrays.stream(codeArr)
-                            .map(itemCode -> beUtils.getBaseEntityByCode(itemCode))
+                            .map(itemCode -> beUtils.getBaseEntity(itemCode))
                             .toArray(BaseEntity[]::new);
 
                     if (beArray.length == 1) {

--- a/qwandaq/src/main/java/life/genny/qwandaq/Question.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/Question.java
@@ -369,7 +369,7 @@ public class Question extends CodedEntity implements ICapabilityHiddenFilterable
 	 * @return the default Code prefix for this class.
 	 */
 	static public String getDefaultCodePrefix() {
-		return Prefix.QUE;
+		return Prefix.QUE_;
 	}
 
 	/**

--- a/qwandaq/src/main/java/life/genny/qwandaq/constants/GennyConstants.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/constants/GennyConstants.java
@@ -14,7 +14,7 @@ public final class GennyConstants {
     // ================================== CAPABILITY CONSTANTS =============================================
 	// Capability Attribute Prefix
 	public static final String PRI_IS_PREFIX = "PRI_IS_";
-	public static final String[] ACCEPTED_CAP_PREFIXES = { Prefix.ROL, Prefix.PER, Prefix.DEF };
+	public static final String[] ACCEPTED_CAP_PREFIXES = { Prefix.ROL_, Prefix.PER_, Prefix.DEF_ };
 	public static final String DEF_ROLE_CODE = "DEF_ROLE";
 	
 	// =====================================================================================================

--- a/qwandaq/src/main/java/life/genny/qwandaq/constants/Prefix.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/constants/Prefix.java
@@ -6,49 +6,49 @@ package life.genny.qwandaq.constants;
 public class Prefix {
 
 	// core
-	public static final String QUE = "QUE_";
-	public static final String QBE = "QBE_";
-	public static final String PCM = "PCM_";
-	public static final String ROL = "ROL_";
-	public static final String PRJ = "PRJ_";
-	public static final String EVT = "EVT_";
-	public static final String SEL = "SEL_";
+	public static final String QUE_ = "QUE_";
+	public static final String QBE_ = "QBE_";
+	public static final String PCM_ = "PCM_";
+	public static final String ROL_ = "ROL_";
+	public static final String PRJ_ = "PRJ_";
+	public static final String EVT_ = "EVT_";
+	public static final String SEL_ = "SEL_";
 
 	// baseentity
-	public static final String PER = "PER_";
-	public static final String CPY = "CPY_";
-	public static final String MSG = "MSG_";
+	public static final String PER_ = "PER_";
+	public static final String CPY_ = "CPY_";
+	public static final String MSG_ = "MSG_";
 
 	// attribute
-	public static final String PRI = "PRI_";
-	public static final String LNK = "LNK_";
-	public static final String LOCATION = "PRI_LOC";
+	public static final String PRI_ = "PRI_";
+	public static final String LNK_ = "LNK_";
+	public static final String PRI_LOC = "PRI_LOC";
 
 	// definition
-	public static final String DEF = "DEF_";
-	public static final String ATT = "ATT_";
-	public static final String DFT = "DFT_";
-	public static final String SER = "SER_";
-	public static final String DEP = "DEP_";
-	public static final String UNQ = "UNQ_";
+	public static final String DEF_ = "DEF_";
+	public static final String ATT_ = "ATT_";
+	public static final String DFT_ = "DFT_";
+	public static final String SER_ = "SER_";
+	public static final String DEP_ = "DEP_";
+	public static final String UNQ_ = "UNQ_";
 
 	// pcm
-	public static final String TPL = "TPL_";
+	public static final String TPL_ = "TPL_";
 
 	// capability
-	public static final String CAP = "CAP_";
-	public static final String PRM = "PRM_";
+	public static final String CAP_ = "CAP_";
+	public static final String PRM_ = "PRM_";
 
 	// search entity
-	public static final String SBE = "SBE_";
-	public static final String FLC = "FLC_";
-	public static final String COL = "COL_";
-	public static final String ACT = "ACT_";
-	public static final String SRT = "SRT_";
+	public static final String SBE_ = "SBE_";
+	public static final String FLC_ = "FLC_";
+	public static final String COL_ = "COL_";
+	public static final String ACT_ = "ACT_";
+	public static final String SRT_ = "SRT_";
 
 	// Table
-	public static final String QUE_TABLE_PREF = "QUE_TABLE_";
-	public static final String FIELD="FIELD_";
+	public static final String QUE_TABLE_ = "QUE_TABLE_";
+	public static final String FIELD_ = "FIELD_";
 
 }
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/BaseEntity.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/BaseEntity.java
@@ -1187,7 +1187,7 @@ public class BaseEntity extends CodedEntity implements BaseEntityIntf, ICapabili
 
 	@JsonbTransient
 	public boolean isPerson() {
-		return getCode().startsWith(Prefix.PER);
+		return getCode().startsWith(Prefix.PER_);
 	}
 
 	/**

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/Definition.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/Definition.java
@@ -42,21 +42,21 @@ public class Definition extends BaseEntity {
 	}
 
 	public void setAllowedAttribute(String attributeCode, Boolean mandatory) {
-		setValue(Prefix.ATT.concat(attributeCode), mandatory);
+		setValue(Prefix.ATT_.concat(attributeCode), mandatory);
 	}
 
 	@JsonbTransient
 	public List<EntityAttribute> getAllowedAttributes() {
-		return findPrefixEntityAttributes(Prefix.ATT);
+		return findPrefixEntityAttributes(Prefix.ATT_);
 	}
 
 	public void setDefaultValue(String attributeCode, Object value) {
-		setValue(Prefix.DFT.concat(attributeCode), value);
+		setValue(Prefix.DFT_.concat(attributeCode), value);
 	}
 
 	@JsonbTransient
 	public List<EntityAttribute> getDefaultValues() {
-		return findPrefixEntityAttributes(Prefix.DFT);
+		return findPrefixEntityAttributes(Prefix.DFT_);
 	}
 
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/trait/Action.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/trait/Action.java
@@ -9,7 +9,7 @@ import life.genny.qwandaq.constants.Prefix;
 @RegisterForReflection
 public class Action extends Trait {
 
-	public static final String PREFIX = Prefix.ACT;
+	public static final String PREFIX = Prefix.ACT_;
 
 	public static final String VIEW = "VIEW";
 	public static final String EDIT = "EDIT";

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/trait/Column.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/trait/Column.java
@@ -9,7 +9,7 @@ import life.genny.qwandaq.constants.Prefix;
 @RegisterForReflection
 public class Column extends Trait {
 
-	public static final String PREFIX = Prefix.COL;
+	public static final String PREFIX = Prefix.COL_;
 
 	public Column() {
 		super();

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/trait/Sort.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/trait/Sort.java
@@ -9,7 +9,7 @@ import life.genny.qwandaq.constants.Prefix;
 @RegisterForReflection
 public class Sort extends Trait {
 
-	public static final String PREFIX = Prefix.SRT;
+	public static final String PREFIX = Prefix.SRT_;
 
 	private Ord order;
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
@@ -130,7 +130,7 @@ public class CapabilitiesManager extends Manager {
 	 * @return
 	 */
 	public CapabilitySet getEntityCapabilities(final BaseEntity target) {
-		Set<EntityAttribute> capabilities = new HashSet<>(target.findPrefixEntityAttributes(Prefix.CAP));
+		Set<EntityAttribute> capabilities = new HashSet<>(target.findPrefixEntityAttributes(Prefix.CAP_));
 		log.debug("		- " + target.getCode() + "(" + capabilities.size() + " capabilities)");
 		if(capabilities.isEmpty()) {
 			return new CapabilitySet(target);
@@ -335,8 +335,8 @@ public class CapabilitiesManager extends Manager {
 	 */
 	public static String cleanCapabilityCode(final String rawCapabilityCode) {
 		String cleanCapabilityCode = rawCapabilityCode.toUpperCase();
-		if (!cleanCapabilityCode.startsWith(Prefix.CAP)) {
-			cleanCapabilityCode = Prefix.CAP + cleanCapabilityCode;
+		if (!cleanCapabilityCode.startsWith(Prefix.CAP_)) {
+			cleanCapabilityCode = Prefix.CAP_ + cleanCapabilityCode;
 		}
 
 		return cleanCapabilityCode;

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -246,7 +246,7 @@ public class RoleManager extends Manager {
 	 */
 	public BaseEntity inheritRole(String productCode, BaseEntity role, final BaseEntity parentRole) {
 		BaseEntity ret = role;
-		List<EntityAttribute> perms = parentRole.findPrefixEntityAttributes(Prefix.CAP);
+		List<EntityAttribute> perms = parentRole.findPrefixEntityAttributes(Prefix.CAP_);
 		for (EntityAttribute permissionEA : perms) {
 			Attribute permission = permissionEA.getAttribute();
 			List<CapabilityNode> capabilities = CapabilitiesManager.deserializeCapArray(permissionEA.getValue());
@@ -367,8 +367,8 @@ public class RoleManager extends Manager {
 
 	public static String cleanRoleCode(final String rawRoleCode) {
 		String cleanRoleCode = rawRoleCode.toUpperCase();
-		if (!cleanRoleCode.startsWith(Prefix.ROL)) {
-			cleanRoleCode = Prefix.ROL + cleanRoleCode;
+		if (!cleanRoleCode.startsWith(Prefix.ROL_)) {
+			cleanRoleCode = Prefix.ROL_ + cleanRoleCode;
 		}
 
 		return cleanRoleCode;

--- a/qwandaq/src/main/java/life/genny/qwandaq/message/QMessageGennyMSG.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/message/QMessageGennyMSG.java
@@ -261,7 +261,7 @@ public class QMessageGennyMSG extends QMessage {
 				log.warn("Message does not contain a Template Code!!");
 			} else {
 				// Make sure template exists
-				BaseEntity templateBE = beUtils.getBaseEntityByCode(this.msg.getTemplateCode());
+				BaseEntity templateBE = beUtils.getBaseEntity(this.msg.getTemplateCode());
 
 				if (templateBE == null) {
 					log.error("Message template " + this.msg.getTemplateCode() + " does not exist!!");

--- a/qwandaq/src/main/java/life/genny/qwandaq/models/GennyToken.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/models/GennyToken.java
@@ -164,7 +164,7 @@ public class GennyToken implements Serializable {
 		this.adecodedTokenMap.put("realm", this.realm);
 
 		String username = getString("preferred_username");
-		this.userUUID = Prefix.PER + this.getUuid().toUpperCase();
+		this.userUUID = Prefix.PER_ + this.getUuid().toUpperCase();
 
 		if ("service".equals(username)) {
 			this.userCode = "PER_SERVICE";
@@ -538,7 +538,7 @@ public class GennyToken implements Serializable {
 	public String getEmailUserCode() {
 		String username = (String) adecodedTokenMap.get("preferred_username");
 		String normalisedUsername = getNormalisedUsername(username);
-		return Prefix.PER + normalisedUsername.toUpperCase();
+		return Prefix.PER_ + normalisedUsername.toUpperCase();
 
 	}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/models/SavedSearch.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/models/SavedSearch.java
@@ -35,8 +35,8 @@ public class SavedSearch {
         this.value = "";
 
         if(splitted.length == 2) {
-            this.operator = splitted[0].replaceFirst(Prefix.SEL,"");
-            this.value = splitted[1].replaceFirst(Prefix.SEL,"");
+            this.operator = splitted[0].replaceFirst(Prefix.SEL_,"");
+            this.value = splitted[1].replaceFirst(Prefix.SEL_,"");
         }
         this.column = getColumnName(attributeCode);
         this.valueCode = value;
@@ -149,17 +149,17 @@ public class SavedSearch {
     public String getColumnName(String value) {
         String fieldName = "";
         int priIndex = -1;
-        int fieldIndex = value.lastIndexOf(Prefix.FIELD);
-        int lnkIndex = value.lastIndexOf(Prefix.LNK);
+        int fieldIndex = value.lastIndexOf(Prefix.FIELD_);
+        int lnkIndex = value.lastIndexOf(Prefix.LNK_);
         if(fieldIndex > -1) {
-            priIndex = value.indexOf(Prefix.FIELD) + Prefix.FIELD.length();
+            priIndex = value.indexOf(Prefix.FIELD_) + Prefix.FIELD_.length();
             fieldName = value.substring(priIndex);
             return fieldName;
         }else if(lnkIndex > -1) {
             fieldName = value.substring(lnkIndex);
             return fieldName;
         } else {
-            priIndex = value.lastIndexOf(Prefix.PRI);
+            priIndex = value.lastIndexOf(Prefix.PRI_);
         }
         if(priIndex > -1) {
             fieldName = value.substring(priIndex);

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
@@ -75,7 +75,7 @@ public class DefUtils {
 
 		SearchEntity searchEntity = new SearchEntity(SBE_DEF, "DEF check")
 				.add(new Sort(Attribute.PRI_NAME, Ord.ASC))
-				.add(new Filter(Attribute.PRI_CODE, Operator.STARTS_WITH, Prefix.DEF))
+				.add(new Filter(Attribute.PRI_CODE, Operator.STARTS_WITH, Prefix.DEF_))
 				.setPageStart(0)
 				.setPageSize(10000);
 
@@ -123,7 +123,7 @@ public class DefUtils {
 			throw new NullParameterException("entity");
 
 		// save processing time on particular entities
-		if (entity.getCode().startsWith(Prefix.DEF))
+		if (entity.getCode().startsWith(Prefix.DEF_))
 			return Definition.from(entity);
 
 		List<String> codes = beUtils.getBaseEntityCodeArrayFromLinkAttribute(entity, Attribute.LNK_DEF);
@@ -221,15 +221,15 @@ public class DefUtils {
 		String attributeCode = answer.getAttributeCode();
 
 		// allow if it is Capability saved to a Role
-		if (targetCode.startsWith(Prefix.ROL) && attributeCode.startsWith(Prefix.PRM)) {
+		if (targetCode.startsWith(Prefix.ROL_) && attributeCode.startsWith(Prefix.PRM_)) {
 			return true;
-		} else if (targetCode.startsWith(Prefix.SBE) && (attributeCode.startsWith(Prefix.COL)
-				|| attributeCode.startsWith(Prefix.SRT) || attributeCode.startsWith(Prefix.ACT))) {
+		} else if (targetCode.startsWith(Prefix.SBE_) && (attributeCode.startsWith(Prefix.COL_)
+				|| attributeCode.startsWith(Prefix.SRT_) || attributeCode.startsWith(Prefix.ACT_))) {
 			return true;
 		}
 
 		// just make use of the faster attribute lookup
-		if (!definition.containsEntityAttribute(Prefix.ATT + attributeCode)) {
+		if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
 			log.error(ANSIColour.RED + "Invalid attribute " + attributeCode + " for " + answer.getTargetCode()
 					+ " with def= " + definition.getCode() + ANSIColour.RESET);
 			return false;
@@ -262,16 +262,16 @@ public class DefUtils {
 			throw new NullParameterException("attribute");
 
 		// allow if it is Capability saved to a Role
-		if (defBE.getCode().equals("DEF_ROLE") && attribute.getCode().startsWith(Prefix.PRM)) {
+		if (defBE.getCode().equals("DEF_ROLE") && attribute.getCode().startsWith(Prefix.PRM_)) {
 			return true;
 		} else if (defBE.getCode().equals("DEF_SEARCH")
-				&& (attribute.getCode().startsWith(Prefix.COL) 
-				|| attribute.getCode().startsWith(Prefix.SRT) || attribute.getCode().startsWith(Prefix.ACT))) {
+				&& (attribute.getCode().startsWith(Prefix.COL_) 
+				|| attribute.getCode().startsWith(Prefix.SRT_) || attribute.getCode().startsWith(Prefix.ACT_))) {
 			return true;
 		}
 
 		// just make use of the faster attribute lookup
-		if (!defBE.containsEntityAttribute(Prefix.ATT.concat(attribute.getCode()))) {
+		if (!defBE.containsEntityAttribute(Prefix.ATT_.concat(attribute.getCode()))) {
 			log.error(ANSIColour.RED + "Invalid attribute " + attribute.getCode() + " for "
 					+ defBE.getCode() + ANSIColour.RESET);
 			return false;

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/FilterUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/FilterUtils.java
@@ -118,17 +118,17 @@ public class FilterUtils {
     public String getLinkValueCode(String value) {
         String fieldName = "";
         int priIndex = -1;
-        int fieldIndex = value.lastIndexOf(Prefix.FIELD);
-        int lnkIndex = value.lastIndexOf(Prefix.LNK);
+        int fieldIndex = value.lastIndexOf(Prefix.FIELD_);
+        int lnkIndex = value.lastIndexOf(Prefix.LNK_);
         if(fieldIndex > -1) {
-            priIndex = value.indexOf(Prefix.PRI) + Prefix.PRI.length();
+            priIndex = value.indexOf(Prefix.PRI_) + Prefix.PRI_.length();
             fieldName = value.substring(priIndex,fieldIndex - 1);
             return fieldName;
         }else if(lnkIndex > -1) {
             fieldName = value.substring(lnkIndex);
             return fieldName;
         } else {
-            priIndex = value.lastIndexOf(Prefix.PRI) + Prefix.PRI.length();
+            priIndex = value.lastIndexOf(Prefix.PRI_) + Prefix.PRI_.length();
         }
         if(priIndex > -1) {
             fieldName = value.substring(priIndex);
@@ -188,17 +188,17 @@ public class FilterUtils {
         List<BaseEntity> baseEntities = new ArrayList<>();
 
         searchBE.getBaseEntityAttributes().stream()
-                .filter(e -> e.getAttributeCode().startsWith(Prefix.FLC))
+                .filter(e -> e.getAttributeCode().startsWith(Prefix.FLC_))
                 .forEach(e -> {
                     BaseEntity baseEntity = new BaseEntity();
                     List<EntityAttribute> entityAttributes = new ArrayList<>();
 
                     EntityAttribute ea = new EntityAttribute();
-                    String attrCode = e.getAttributeCode().replaceFirst(Prefix.FLC, "");
+                    String attrCode = e.getAttributeCode().replaceFirst(Prefix.FLC_, "");
                     ea.setAttributeName(e.getAttributeName());
                     ea.setAttributeCode(attrCode);
 
-                    String baseCode = FilterConst.FILTER_SEL + Prefix.FLC + attrCode;
+                    String baseCode = FilterConst.FILTER_SEL + Prefix.FLC_ + attrCode;
                     ea.setBaseEntityCode(baseCode);
                     ea.setValueString(e.getAttributeName());
 
@@ -303,8 +303,8 @@ public class FilterUtils {
      */
     public SearchEntity getQuickOptions(String sbeCode,String lnkCode, String lnkValue) {
         SearchEntity searchBE = new SearchEntity(sbeCode,sbeCode);
-        searchBE.add(new Or(new Filter(Attribute.PRI_CODE, Operator.STARTS_WITH, Prefix.CPY)
-                        ,new Filter(Attribute.PRI_CODE, Operator.STARTS_WITH, Prefix.PER)))
+        searchBE.add(new Or(new Filter(Attribute.PRI_CODE, Operator.STARTS_WITH, Prefix.CPY_)
+                        ,new Filter(Attribute.PRI_CODE, Operator.STARTS_WITH, Prefix.PER_)))
                 .add(new Column(lnkCode, lnkCode));
 
         if(!lnkValue.isEmpty()) {
@@ -381,7 +381,7 @@ public class FilterUtils {
         if(attCode.equalsIgnoreCase(Attribute.LNK_FILTER_COLUMN) ||
                 attCode.equalsIgnoreCase(Attribute.LNK_SAVED_SEARCH) ||
                 attCode.equalsIgnoreCase(Attribute.LNK_QUICK_SEARCH) ||
-                attCode.startsWith(Prefix.FLC)){
+                attCode.startsWith(Prefix.FLC_)){
             return true;
         }
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/GithubUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/GithubUtils.java
@@ -262,7 +262,7 @@ public class GithubUtils {
                     String existingUrl = lays.get(layoutCode);
                     BaseEntity layout = null;
                     try {
-                        layout = beUtils.getBaseEntityOrNull(realm, layoutCode);
+                        layout = beUtils.getBaseEntity(realm, layoutCode);
                     } catch (ItemNotFoundException e) {
                         log.info("No be found for " + layoutCode);
                     }

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/KeycloakUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/KeycloakUtils.java
@@ -220,7 +220,7 @@ public class KeycloakUtils {
         String keycloakUrl = serviceToken.getKeycloakUrl().replace(":-1", "");
 
         // grab uuid to fetch token
-        String uuid = userCode.substring(Prefix.PER.length()).toLowerCase();
+        String uuid = userCode.substring(Prefix.PER_.length()).toLowerCase();
 
         // setup param map
         HashMap<String, String> params = new HashMap<>();

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -64,7 +64,7 @@ import life.genny.qwandaq.validation.Validation;
 @ApplicationScoped
 public class QwandaUtils {
 
-	public static final String[] ACCEPTED_PREFIXES = { Prefix.PRI, Prefix.LNK };
+	public static final String[] ACCEPTED_PREFIXES = { Prefix.PRI_, Prefix.LNK_ };
 	public static final String[] EXCLUDED_ATTRIBUTES = { Attribute.PRI_SUBMIT, Attribute.EVT_SUBMIT,
 			Attribute.EVT_CANCEL, Attribute.EVT_NEXT };
 
@@ -244,8 +244,8 @@ public class QwandaUtils {
 	 * @return
 	 */
 	public Attribute createButtonEvent(String code, final String name) {
-		if (!code.startsWith(Prefix.EVT))
-			code = Prefix.EVT.concat(code);
+		if (!code.startsWith(Prefix.EVT_))
+			code = Prefix.EVT_.concat(code);
 		code = code.toUpperCase();
 		DataType DTT_EVENT = getAttribute(userToken.getProductCode(), Attribute.EVT_SUBMIT).getDataType();
 		return new Attribute(code, name.concat(" Event"), DTT_EVENT);
@@ -449,10 +449,10 @@ public class QwandaUtils {
 	 */
 	public Map<String, Ask> updateDependentAsks(BaseEntity target, Definition definition, Map<String, Ask> flatMapAsks) {
 
-		List<EntityAttribute> dependentAsks = definition.findPrefixEntityAttributes(Prefix.DEP);
+		List<EntityAttribute> dependentAsks = definition.findPrefixEntityAttributes(Prefix.DEP_);
 
 		for (EntityAttribute dep : dependentAsks) {
-			String attributeCode = StringUtils.removeStart(dep.getAttributeCode(), Prefix.DEP);
+			String attributeCode = StringUtils.removeStart(dep.getAttributeCode(), Prefix.DEP_);
 			Ask targetAsk = flatMapAsks.get(attributeCode);
 			if (targetAsk == null)
 				continue;
@@ -819,14 +819,14 @@ public class QwandaUtils {
 
 		// create a child ask for every valid atribute
 		definition.getBaseEntityAttributes().stream()
-				.filter(ea -> ea.getAttributeCode().startsWith(Prefix.ATT))
+				.filter(ea -> ea.getAttributeCode().startsWith(Prefix.ATT_))
 				.forEach((ea) -> {
-					String attributeCode = StringUtils.removeStart(ea.getAttributeCode(), Prefix.ATT);
+					String attributeCode = StringUtils.removeStart(ea.getAttributeCode(), Prefix.ATT_);
 					Attribute attribute = getAttributeByBaseEntityAndCode(baseEntity, attributeCode);
 
-					String questionCode = Prefix.QUE
+					String questionCode = Prefix.QUE_
 							+ StringUtils.removeStart(StringUtils.removeStart(attribute.getCode(),
-									Prefix.PRI), Prefix.LNK);
+									Prefix.PRI_), Prefix.LNK_);
 
 					Question childQues = new Question(questionCode, attribute.getName(), attribute);
 					Ask childAsk = new Ask(childQues, sourceCode, targetCode);
@@ -883,7 +883,7 @@ public class QwandaUtils {
 			throw new NullParameterException("baseEntity");
 		
 		// Convert to DEF
-		if(!baseEntity.getCode().startsWith(Prefix.DEF)) {
+		if(!baseEntity.getCode().startsWith(Prefix.DEF_)) {
 			baseEntity = defUtils.getDEF(baseEntity);
 		}
 
@@ -919,7 +919,7 @@ public class QwandaUtils {
 			throw new NullParameterException("baseEntity");
 		
 		// Convert to DEF
-		if(!baseEntity.getCode().startsWith(Prefix.DEF)) {
+		if(!baseEntity.getCode().startsWith(Prefix.DEF_)) {
 			baseEntity = defUtils.getDEF(baseEntity);
 		}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/SearchUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/SearchUtils.java
@@ -179,7 +179,7 @@ public class SearchUtils {
 	 */
 	public void searchTable(String code) {
 
-		if (!code.startsWith(Prefix.SBE))
+		if (!code.startsWith(Prefix.SBE_))
 			throw new DebugException("Code " + code + " does not represent a SearchEntity");
 
 		log.debug("Performing Table Search: " + code);

--- a/qwandaq/src/test/java/life/genny/test/qwandaq/constants/StringConstantsTest.java
+++ b/qwandaq/src/test/java/life/genny/test/qwandaq/constants/StringConstantsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import life.genny.qwandaq.Question;
 import life.genny.qwandaq.attribute.Attribute;
+import life.genny.qwandaq.constants.Prefix;
 import life.genny.qwandaq.entity.PCM;
 import life.genny.qwandaq.utils.testsuite.JUnitTester;
 import life.genny.test.qwandaq.utils.BaseTestCase;
@@ -32,6 +33,11 @@ public class StringConstantsTest extends BaseTestCase {
 
             .createTest("PCM Code Constants")
             .setInput(PCM.class)
+            .setExpected(true)
+            .build()
+
+            .createTest("Prefix Constants")
+            .setInput(Prefix.class)
             .setExpected(true)
             .build()
 


### PR DESCRIPTION
#### Changes in this PR
- Rename all Prefix constants to an accurate representation of their value.
- Added Prefix class to String Constant Tests
- Delete `getBaseEntityByCode` and `getBaseEntityOrNull` method definitions and references in favour of `getBaseEntity`