### PR TITLE
For GennySettings only throw exception if there is no default

### DIFF
--- a/qwandaq/src/main/java/life/genny/qwandaq/models/GennySettings.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/models/GennySettings.java
@@ -34,7 +34,7 @@ public class GennySettings {
 	 * */
 	private static final String getConfig(String env, String fallback, boolean alert) 
 		throws IllegalStateException {
-		String value = CommonUtils.getSystemEnv(env, alert);
+		String value = CommonUtils.getSystemEnv(env, alert && fallback == null);
 		if(StringUtils.isBlank(value)) {
 			if(fallback != null) {
 				log.warn("Using fallback for " + env + ": " + fallback);

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
@@ -136,11 +136,10 @@ public class CommonUtils {
     public static String getSystemEnv(String env, boolean alert) {
         String result = System.getenv(env);
         if(result == null && alert) {
-            String msg = "Could not find System Environment Variable: " + env;
             if(alert) {
-                throw new MissingEnvironmentVariableException(msg);
+                throw new MissingEnvironmentVariableException(env);
             } else {
-                log.warn(msg);
+                log.warn("Could not find System Environment Variable: " + env);
             }
         }
 


### PR DESCRIPTION
This will fix current issue in dropkick ([LOJ-559](https://gada.atlassian.net/browse/LOJ-559))
In the scheme of GennySettings, it should only throw an Exception if there is no default value (how it used to behave). This PR remedies this

[LOJ-559]: https://gada.atlassian.net/browse/LOJ-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ