### PR TITLE
Fix duplicate alert check, and not logging at all if alert is false

### DIFF
--- a/qwandaq/src/main/java/life/genny/qwandaq/models/GennySettings.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/models/GennySettings.java
@@ -32,7 +32,7 @@ public class GennySettings {
 	 * @param fallback - default value in the case the environment variable is not present
 	 * @param alert - whether or not to log a warning if the environment variable is missing
 	 * */
-	private static final String getConfig(String env, String fallback, boolean alert) 
+	private static final String getConfig(String env, String fallback, boolean alert) // env: PROJECT_URL, fallback:"http://alyson.genny.life", alert: true
 		throws IllegalStateException {
 		String value = CommonUtils.getSystemEnv(env, alert && fallback == null);
 		if(StringUtils.isBlank(value)) {

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
@@ -130,17 +130,18 @@ public class CommonUtils {
     /**
      * A method to retrieve a system environment variable, and optionally log it if it is missing (default, do log)
      * @param env Env to retrieve
-     * @param alert whether or not to log if it is missing or not (default: true)
+     * @param alert whether or not to throw an excpetion or just log if it is missing or not (default: true)
      * @return the value of the environment variable, or null if it cannot be found
      */
     public static String getSystemEnv(String env, boolean alert) {
         String result = System.getenv(env);
+        
+        String msg = "Could not find System Environment Variable: " + env;
+
         if(result == null && alert) {
-            if(alert) {
-                throw new MissingEnvironmentVariableException(env);
-            } else {
-                log.warn("Could not find System Environment Variable: " + env);
-            }
+            throw new MissingEnvironmentVariableException(msg);
+        } else {
+            log.warn(msg);
         }
 
         return result;


### PR DESCRIPTION
This has a small optimisation and also brings back logging a warning if there is a missing environment variable, and the alert flag in the getSystemEnv method is false. Previously it would not log the warning due to the duplicate alert check