### PR TITLE
Bug fixes

### DIFF
--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/BaseEntity.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/BaseEntity.java
@@ -1216,7 +1216,6 @@ public class BaseEntity extends CodedEntity implements BaseEntityIntf, ICapabili
 	public void decorate(BaseEntity other) {
 		other.setCapabilityRequirements(getCapabilityRequirements());
 		other.setRealm(getRealm());
-		other.setRealm(getRealm());
 		other.setBaseEntityAttributes(getBaseEntityAttributes());
 	}
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
@@ -136,12 +136,10 @@ public class CommonUtils {
     public static String getSystemEnv(String env, boolean alert) {
         String result = System.getenv(env);
         
-        String msg = "Could not find System Environment Variable: " + env;
-
         if(result == null && alert) {
-            throw new MissingEnvironmentVariableException(msg);
+            throw new MissingEnvironmentVariableException(env);
         } else {
-            log.warn(msg);
+            log.warn("Could not find System Environment Variable: " + env);
         }
 
         return result;


### PR DESCRIPTION
Clean up duplicate method call in BaseEntity.decorate
Clean up log line/code in CommonUtils
Check Database after null return on check Cache. Passively populate cache with missing attributes if they exist in Database

I am aware that the consistency between the database and the cache will be vastly improved after the cache updates, however for now this will help with the mismatch in attribute data after bootq_loading new attributes (saving us a server restart)