### PR TITLE
null dtt check + error log

### DIFF
--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/AttributeUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/AttributeUtils.java
@@ -4,11 +4,11 @@ import life.genny.qwandaq.attribute.Attribute;
 import life.genny.qwandaq.constants.GennyConstants;
 import life.genny.qwandaq.datatype.DataType;
 import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
+import life.genny.qwandaq.exception.runtime.NullParameterException;
 import life.genny.qwandaq.managers.CacheManager;
 import life.genny.qwandaq.models.UserToken;
 import life.genny.qwandaq.serialization.attribute.AttributeKey;
 import life.genny.qwandaq.serialization.datatype.DataTypeKey;
-import life.genny.qwandaq.serialization.validation.ValidationKey;
 import life.genny.qwandaq.validation.Validation;
 import org.jboss.logging.Logger;
 
@@ -16,7 +16,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -98,9 +97,18 @@ public class AttributeUtils {
     }
 
     public DataType getDataType(Attribute attribute, boolean bundleValidationList) {
+        if(attribute == null) {
+            throw new NullParameterException("attribute");
+        }
+
         DataTypeKey key = new DataTypeKey(attribute.getRealm(), attribute.getDttCode());
         DataType dataType = (DataType) cm.getPersistableEntity(GennyConstants.CACHE_NAME_DATATYPE, key);
-        if (bundleValidationList && dataType != null) {
+
+        if(dataType == null) {
+            throw new ItemNotFoundException("DataType attached to Attribute: " + attribute.getCode());
+        }
+
+        if (bundleValidationList) {
             List<Validation> validationList = getValidationList(dataType);
             dataType.setValidationList(validationList);
         }

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -681,6 +681,12 @@ public class QwandaUtils {
 			} else {
 				attribute = ea.getAttribute();
 			}
+
+			if(attribute.getDataType() == null) {
+				log.error("[!] Detected Null DataType for attribute: " + attribute.getCode());
+				continue;
+			}
+
 			String className = attribute.getDataType().getClassName();
 			Object value = ea.getValue();
 


### PR DESCRIPTION
There are attributes with null datatypes due to bad bootq batch loading (under maintenance by myself at the mo). This isn't a fix but will help identify where the bad data is, so we can at least fix it in the sheets while we fix bootq.

This code will stop the workflow from crashing due to this NPE, but it almost certainly will not provide the functionality originally intended in this code (QwandaUtils#generateProcessEntity). If it finds bad datatype it skips the attribute. So process entity will come out with missing attributes and notify of bad data in logs until we fix them in sheets, which seems okay in the very immediate short term to me. 

If there are better suggestions we should definitely seek to implement them to combat the bad data until we have BootstrapAPI