### PR TITLE
10.3.0 consolidated fyodor eafix

### DIFF
--- a/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
@@ -114,19 +114,15 @@ public class FyodorUltra {
 			for (String attributeCode : allowed) {
 				EntityAttribute ea;
 				if (attributeCode.startsWith("_")) {
-					log.debug(ANSIColour.RED + "Getting associated column value of: " + attributeCode + ANSIColour.RESET);
 					// handle asociated columns
 					try {
 						ea = getAssociatedColumnValue(baseEntity, attributeCode);
 						// De-escalate the known issue and skip the bad ea
 					} catch(BadDataException e) {
-						log.error(e.getMessage());
+						log.error(ANSIColour.RED + e.getMessage() + ANSIColour.RESET);
 						continue;
 					}
-					// if(ea == null) {
-					// 	log.warn("Got bad ea: " + baseEntity.getCode() + ":" + attributeCode + ". Skipping");
-					// 	continue;
-					// }
+					
 					// set attr codes to associated code
 					ea.setAttributeCode(attributeCode);
 					ea.getAttribute().setCode(attributeCode);

--- a/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
@@ -115,11 +115,17 @@ public class FyodorUltra {
 				if (attributeCode.startsWith("_")) {
 					log.debug("Getting associated column value of: " + attributeCode);
 					// handle asociated columns
-					ea = getAssociatedColumnValue(baseEntity, attributeCode);
-					if(ea == null) {
-						log.warn("Got bad ea: " + baseEntity.getCode() + ":" + attributeCode + ". Skipping");
+					try {
+						ea = getAssociatedColumnValue(baseEntity, attributeCode);
+						// De-escalate the known issue and skip the bad ea
+					} catch(BadDataException e) {
+						log.error(e.getMessage());
 						continue;
 					}
+					// if(ea == null) {
+					// 	log.warn("Got bad ea: " + baseEntity.getCode() + ":" + attributeCode + ". Skipping");
+					// 	continue;
+					// }
 					// set attr codes to associated code
 					ea.setAttributeCode(attributeCode);
 					ea.getAttribute().setCode(attributeCode);

--- a/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
@@ -55,6 +55,7 @@ import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
 import life.genny.qwandaq.exception.runtime.NullParameterException;
 import life.genny.qwandaq.exception.runtime.QueryBuilderException;
 import life.genny.qwandaq.managers.CacheManager;
+import life.genny.qwandaq.models.ANSIColour;
 import life.genny.qwandaq.models.Page;
 import life.genny.qwandaq.models.UserToken;
 import life.genny.qwandaq.utils.BaseEntityUtils;
@@ -113,7 +114,7 @@ public class FyodorUltra {
 			for (String attributeCode : allowed) {
 				EntityAttribute ea;
 				if (attributeCode.startsWith("_")) {
-					log.debug("Getting associated column value of: " + attributeCode);
+					log.debug(ANSIColour.RED + "Getting associated column value of: " + attributeCode + ANSIColour.RESET);
 					// handle asociated columns
 					try {
 						ea = getAssociatedColumnValue(baseEntity, attributeCode);


### PR DESCRIPTION
This fixes bad data stopping the display of tables and other such BEA related displays.
One question to ask: Why do we do a 2nd count query when we have the same number through items.size() ? At a glance we could use this size before we paginate to set the number of items