### PR TITLE
10.3.0 fyodor capfix

### DIFF
--- a/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
@@ -49,6 +49,8 @@ public class CapHandler extends Manager {
 		if(!searchEntity.hasRequirements()) {
 			log.debug("no requirements to check for searchEntity: " + searchEntity.getCode() + ". Skipping");
 			return;
+		} else {
+			log.debug("FOUND Requirements for " + searchEntity.getCode() + " generating user capabilities");
 		}
 
 		CapabilitySet userCapabilities = capMan.getUserCapabilities();

--- a/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
@@ -45,6 +45,12 @@ public class CapHandler extends Manager {
 		// NOTE: This line may be a double up, but there are issues otherwise.
 		if (hasSecureToken(userToken))
 			return;
+		
+		if(!searchEntity.hasRequirements()) {
+			log.debug("no requirements to check for searchEntity: " + searchEntity.getCode() + ". Skipping");
+			return;
+		}
+
 		CapabilitySet userCapabilities = capMan.getUserCapabilities();
 		refineColumnsFromCapabilities(searchEntity, userCapabilities);
 		refineActionsFromCapabilities(searchEntity, userCapabilities);

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/SearchEntity.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/SearchEntity.java
@@ -90,6 +90,30 @@ public class SearchEntity extends BaseEntity {
 		setPageSize(20);
 	}
 
+	/**
+	 * Check whether anything in this search entity has capability requirements
+	 * @return <b>true</b> if there is at least one CapabilityRequirement. <b>false</b> otherwise
+	 */
+	@JsonbTransient
+	public boolean hasRequirements() {
+		// Yucky n2. Will need to modify this later
+		for(Map.Entry<Integer, List<? extends Trait>> traitList : traits.entrySet()) {
+			for(Trait t : traitList.getValue()) {
+				if(!t.getCapabilityRequirements().isEmpty())
+					return true;
+			}
+		}
+
+		for(ClauseContainer c : clauseContainers) {
+			if(c.getFilter() != null) {
+				if(!c.getFilter().getCapabilityRequirements().isEmpty())
+					return true;
+			}
+		}
+
+		return false;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * 


### PR DESCRIPTION
This makes Fyodor check capabilities in searches only when required (It is O(n2) time which is annoying but the collection is small so it is very fine for now. I will revisit this if necessary later, probably make it O(1) by updating a flag on construction of SearchEntity)