### PR TITLE
Answer valid for def broke with the separation of def entity attributes between parent and child defs

### DIFF
--- a/lauchy/src/main/java/life/genny/lauchy/Validator.java
+++ b/lauchy/src/main/java/life/genny/lauchy/Validator.java
@@ -185,17 +185,18 @@ public class Validator {
 		if (!target.getCode().equals(answer.getTargetCode()))
 			return blacklist("TargetCode " + target.getCode() + " does not match answer target " + answer.getTargetCode());
 
-		boolean notValidForAnyDefinition = !defUtils.answerValidForDEF(answer);
-		// for (String code : processData.getDefCodes()) {
-		// 	Definition definition = beUtils.getDefinition(code);
-		// 	log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
+		boolean notValidForAnyDefinition = false;//!defUtils.answerValidForDEF(answer);
+		for (String code : processData.getDefCodes()) {
+			Definition definition = beUtils.getDefinition(code);
+			log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
 
-		// 	// check attribute code is allowed by target DEF
-		// 	if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
-		// 		log.warn("AttributeCode " + attributeCode + " not allowed for " + definition.getCode());
-		// 		notValidForAnyDefinition = true;
-		// 	}
-		// }
+			// check attribute code is allowed by target DEF
+			if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
+				log.warn("AttributeCode " + attributeCode + " not allowed for " + definition.getCode());
+				notValidForAnyDefinition = true;
+				break;
+			}
+		}
 
 		if (notValidForAnyDefinition) {
 			return blacklist("Attribute NOT Valid for any definition!");

--- a/lauchy/src/main/java/life/genny/lauchy/Validator.java
+++ b/lauchy/src/main/java/life/genny/lauchy/Validator.java
@@ -54,6 +54,9 @@ public class Validator {
 	BaseEntityUtils beUtils;
 
 	@Inject
+	DefUtils defUtils;
+
+	@Inject
 	EntityAttributeUtils beaUtils;
 
 	@Inject
@@ -182,17 +185,17 @@ public class Validator {
 		if (!target.getCode().equals(answer.getTargetCode()))
 			return blacklist("TargetCode " + target.getCode() + " does not match answer target " + answer.getTargetCode());
 
-		boolean notValidForAnyDefinition = false;
-		for (String code : processData.getDefCodes()) {
-			Definition definition = beUtils.getDefinition(code);
-			log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
+		boolean notValidForAnyDefinition = !defUtils.answerValidForDEF(answer);
+		// for (String code : processData.getDefCodes()) {
+		// 	Definition definition = beUtils.getDefinition(code);
+		// 	log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
 
-			// check attribute code is allowed by target DEF
-			if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
-				log.warn("AttributeCode " + attributeCode + " not allowed for " + definition.getCode());
-				notValidForAnyDefinition = true;
-			}
-		}
+		// 	// check attribute code is allowed by target DEF
+		// 	if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
+		// 		log.warn("AttributeCode " + attributeCode + " not allowed for " + definition.getCode());
+		// 		notValidForAnyDefinition = true;
+		// 	}
+		// }
 
 		if (notValidForAnyDefinition) {
 			return blacklist("Attribute NOT Valid for any definition!");

--- a/lauchy/src/main/java/life/genny/lauchy/Validator.java
+++ b/lauchy/src/main/java/life/genny/lauchy/Validator.java
@@ -188,6 +188,7 @@ public class Validator {
 		boolean notValidForAnyDefinition = false;//!defUtils.answerValidForDEF(answer);
 		for (String code : processData.getDefCodes()) {
 			Definition definition = beUtils.getDefinition(code);
+			log.info("Definition Attributes: " + CommonUtils.getArrayString(definition.getBaseEntityAttributesMap().keySet()));
 			log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
 
 			// check attribute code is allowed by target DEF

--- a/lauchy/src/main/java/life/genny/lauchy/Validator.java
+++ b/lauchy/src/main/java/life/genny/lauchy/Validator.java
@@ -185,7 +185,7 @@ public class Validator {
 		if (!target.getCode().equals(answer.getTargetCode()))
 			return blacklist("TargetCode " + target.getCode() + " does not match answer target " + answer.getTargetCode());
 
-		// boolean notValidForAnyDefinition = false;//!defUtils.answerValidForDEF(answer);
+		boolean notValidForAnyDefinition = false;//!defUtils.answerValidForDEF(answer);
 		// for (String code : processData.getDefCodes()) {
 		// 	Definition definition = beUtils.getDefinition(code);
 		// 	log.info("Definition Attributes: " + CommonUtils.getArrayString(definition.getBaseEntityAttributesMap().keySet()));

--- a/lauchy/src/main/java/life/genny/lauchy/Validator.java
+++ b/lauchy/src/main/java/life/genny/lauchy/Validator.java
@@ -185,19 +185,19 @@ public class Validator {
 		if (!target.getCode().equals(answer.getTargetCode()))
 			return blacklist("TargetCode " + target.getCode() + " does not match answer target " + answer.getTargetCode());
 
-		boolean notValidForAnyDefinition = false;//!defUtils.answerValidForDEF(answer);
-		for (String code : processData.getDefCodes()) {
-			Definition definition = beUtils.getDefinition(code);
-			log.info("Definition Attributes: " + CommonUtils.getArrayString(definition.getBaseEntityAttributesMap().keySet()));
-			log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
+		// boolean notValidForAnyDefinition = false;//!defUtils.answerValidForDEF(answer);
+		// for (String code : processData.getDefCodes()) {
+		// 	Definition definition = beUtils.getDefinition(code);
+		// 	log.info("Definition Attributes: " + CommonUtils.getArrayString(definition.getBaseEntityAttributesMap().keySet()));
+		// 	log.infof("Definition %s found for target %s", definition.getCode(), answer.getTargetCode());
 
-			// check attribute code is allowed by target DEF
-			if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
-				log.warn("AttributeCode " + attributeCode + " not allowed for " + definition.getCode());
-				notValidForAnyDefinition = true;
-				break;
-			}
-		}
+		// 	// check attribute code is allowed by target DEF
+		// 	if (!definition.containsEntityAttribute(Prefix.ATT_ + attributeCode)) {
+		// 		log.warn("AttributeCode " + attributeCode + " not allowed for " + definition.getCode());
+		// 		notValidForAnyDefinition = true;
+		// 		break;
+		// 	}
+		// }
 
 		if (notValidForAnyDefinition) {
 			return blacklist("Attribute NOT Valid for any definition!");

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -20,7 +20,13 @@ import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -354,9 +360,14 @@ public class RoleManager extends Manager {
 	}
 	
 	public List<String> getRoleCodes(BaseEntity personBaseEntity) {
-		List<String> roles = beUtils.getBaseEntityCodeArrayFromLinkAttribute(personBaseEntity, Attribute.LNK_ROLE);
+		List<String> roles;
+		try {
+			roles = beUtils.getBaseEntityCodeArrayFromLinkAttribute(personBaseEntity, Attribute.LNK_ROLE);
+		} catch(ItemNotFoundException e) {
+			return new ArrayList<>();
+		}
 
-		if (roles == null || roles.isEmpty())
+		if (roles.isEmpty())
 			return new ArrayList<String>();
 		return roles;
 	}

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -20,7 +20,6 @@ import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.persistence.NoResultException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -358,7 +357,7 @@ public class RoleManager extends Manager {
 		List<String> roles = beUtils.getBaseEntityCodeArrayFromLinkAttribute(personBaseEntity, Attribute.LNK_ROLE);
 
 		if (roles == null || roles.isEmpty())
-			return new ArrayList<String>();// throw new RoleException(String.format("No roles found for base entity: ", personBaseEntity.getCode()));
+			return new ArrayList<String>();
 		return roles;
 	}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -367,7 +367,7 @@ public class RoleManager extends Manager {
 			return new ArrayList<>();
 		}
 
-		if (roles.isEmpty())
+		if (roles == null || roles.isEmpty())
 			return new ArrayList<String>();
 		return roles;
 	}

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
@@ -311,11 +311,12 @@ public class BaseEntityUtils {
 
 	@Nullable
 	private <T> T getAttributeValue(BaseEntity baseEntity, String attributeCode) {
-		EntityAttribute entityAttribute = beaUtils.getEntityAttribute(baseEntity.getRealm(), baseEntity.getCode(), attributeCode, true);
-		if (entityAttribute == null) {
+		try {
+			EntityAttribute entityAttribute = beaUtils.getEntityAttribute(baseEntity.getRealm(), baseEntity.getCode(), attributeCode, true);
+			return entityAttribute.getValue();
+		} catch(ItemNotFoundException e) {
 			return null;
 		}
-		return entityAttribute.getValue();
 	}
 
 	/**

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
@@ -85,10 +85,10 @@ public class DefUtils {
 	 * @return BaseEntity The corresponding definition {@link BaseEntity}
 	 */
 	public Definition getDEF(final BaseEntity entity) {
-		entity.setBaseEntityAttributes(beaUtils.getAllEntityAttributesForBaseEntity(entity));
-
 		if (entity == null)
 			throw new NullParameterException("entity");
+		entity.setBaseEntityAttributes(beaUtils.getAllEntityAttributesForBaseEntity(entity));
+
 
 		// save processing time on particular entities
 		if (entity.getCode().startsWith(Prefix.DEF_))

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
@@ -23,6 +23,7 @@ import life.genny.qwandaq.entity.search.SearchEntity;
 import life.genny.qwandaq.entity.search.trait.Filter;
 import life.genny.qwandaq.entity.search.trait.Operator;
 import life.genny.qwandaq.exception.runtime.DefinitionException;
+import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
 import life.genny.qwandaq.exception.runtime.NullParameterException;
 import life.genny.qwandaq.managers.CacheManager;
 import life.genny.qwandaq.models.ANSIColour;
@@ -197,9 +198,11 @@ public class DefUtils {
 		}
 
 		// just make use of the faster attribute lookup
-		EntityAttribute ea = beaUtils.getEntityAttribute(definition.getRealm(), definition.getCode(), Prefix.ATT_ + attributeCode);
-		if (ea != null) {
+		try {
+			EntityAttribute ea = beaUtils.getEntityAttribute(definition.getRealm(), definition.getCode(), Prefix.ATT_ + attributeCode);
 			return true;
+		} catch(ItemNotFoundException e) {
+			log.error(e.getMessage());
 		}
 		// if not found, we can check in the parent defs
 		List<String> parentCodes = beUtils.getBaseEntityCodeArrayFromLinkAttribute(definition, Attribute.LNK_INCLUDE);

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
@@ -4,6 +4,7 @@ import life.genny.qwandaq.attribute.Attribute;
 import life.genny.qwandaq.attribute.EntityAttribute;
 import life.genny.qwandaq.constants.GennyConstants;
 import life.genny.qwandaq.entity.BaseEntity;
+import life.genny.qwandaq.entity.Definition;
 import life.genny.qwandaq.entity.PCM;
 import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
 import life.genny.qwandaq.managers.CacheManager;
@@ -17,6 +18,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 /**
  * A non-static utility class used for standard
@@ -30,6 +32,9 @@ public class EntityAttributeUtils {
 
 	@Inject
 	CacheManager cm;
+
+	@Inject
+	BaseEntityUtils beUtils;
 
 	@Inject
 	AttributeUtils attributeUtils;

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
@@ -66,7 +66,9 @@ public class EntityAttributeUtils {
 	 * @param productCode The productCode to use
 	 * @param baseEntityCode        The BaseEntity code of the EntityAttribute to fetch
 	 * @param attributeCode        The Attribute code of the EntityAttribute to fetch
-	 * @return The corresponding EntityAttribute with embedded "Attribute", or null if not found.
+	 * @return The corresponding EntityAttribute with no embedded "Attribute"
+	 * 
+	 * @throws {@link ItemNotFoundException} if no EntityAttribute can be found
 	 */
 	public EntityAttribute getEntityAttribute(String productCode, String baseEntityCode, String attributeCode) {
 		return getEntityAttribute(productCode, baseEntityCode, attributeCode, false);

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -870,7 +870,13 @@ public class QwandaUtils {
 		List<EntityAttribute> uniques = beaUtils.getBaseEntityAttributesForBaseEntityWithAttributeCodePrefix(productCode, definitionCode, Prefix.UNQ_);
 		log.info("Found " + uniques.size() + " UNQ attributes");
 
-		String prefix = beaUtils.getEntityAttribute(productCode, definitionCode, Attribute.PRI_PREFIX).getValueString();
+		EntityAttribute prefixAttribute = beaUtils.getEntityAttribute(productCode, definitionCode, Attribute.PRI_PREFIX);
+		
+		if(prefixAttribute == null) {
+			log.error("Got null prefix for " + definitionCode + ":" + Attribute.PRI_PREFIX);
+		}
+
+		String prefix = prefixAttribute.getValueString();
 
 		for (EntityAttribute entityAttribute : uniques) {
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -593,15 +593,17 @@ public class QwandaUtils {
 		for (String code : attributeCodes) {
 
 			// check for existing attribute in target
-			EntityAttribute ea = beaUtils.getEntityAttribute(productCode, targetCode, code, true, true);
+			EntityAttribute ea;
 			Attribute attribute;
-			if(ea == null) {
+			try {
+				ea = beaUtils.getEntityAttribute(productCode, targetCode, code, true, true);
+			} catch(ItemNotFoundException e) {
 				attribute = attributeUtils.getAttribute(productCode, code, true);
 				// otherwise create new attribute
 				ea = new EntityAttribute(processEntity, attribute, 1.0, null);
-			} else {
-				attribute = ea.getAttribute();
 			}
+
+			attribute = ea.getAttribute();
 
 			if(attribute.getDataType() == null) {
 				log.error("[!] Detected Null DataType for attribute: " + attribute.getCode());

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/QwandaUtils.java
@@ -870,10 +870,16 @@ public class QwandaUtils {
 		List<EntityAttribute> uniques = beaUtils.getBaseEntityAttributesForBaseEntityWithAttributeCodePrefix(productCode, definitionCode, Prefix.UNQ_);
 		log.info("Found " + uniques.size() + " UNQ attributes");
 
-		EntityAttribute prefixAttribute = beaUtils.getEntityAttribute(productCode, definitionCode, Attribute.PRI_PREFIX);
-		
-		if(prefixAttribute == null) {
+		// No uniques, can't be a duplicate right?
+		if(uniques.size() == 0)
+			return false;
+
+		EntityAttribute prefixAttribute;
+		try {
+			prefixAttribute = beaUtils.getEntityAttribute(productCode, definitionCode, Attribute.PRI_PREFIX);
+		} catch(ItemNotFoundException e) {
 			log.error("Got null prefix for " + definitionCode + ":" + Attribute.PRI_PREFIX);
+			return false;
 		}
 
 		String prefix = prefixAttribute.getValueString();


### PR DESCRIPTION
This will unblock us on lojing -> we are lucky in that there are 0 unique attributes in DEF_TENANT at this point, however we should make the entity attribute fetching of definitions more consistent in future. We have access to LNK_INCLUDE, so a breadth first search will suffice (in the event of multiple parent def base entities in the same generation)