### PR TITLE
Fixed detached caps

### DIFF
--- a/bootq/src/main/java/life/genny/bootq/utils/GoogleSheetBuilder.java
+++ b/bootq/src/main/java/life/genny/bootq/utils/GoogleSheetBuilder.java
@@ -71,18 +71,6 @@ public class GoogleSheetBuilder {
 
     public GoogleSheetBuilder() { }
 
-    /**
-	 * Convert a String to a Boolean
-	 *
-     * @param booleanString
-     * @return Boolean or null.
-     */
-    public static boolean toBoolean(final String booleanString) {
-        if (StringUtils.isBlank(booleanString)) {
-            return false;
-        }
-        return "TRUE".equalsIgnoreCase(booleanString);
-    }
 
     /**
 	 * Convert a String to a Double
@@ -202,7 +190,7 @@ public class GoogleSheetBuilder {
         String name = row.get("name");
 
 		// Ensure valid datatype exists
-		validator.validateAttribute(row, realmName);
+		DataType datatype = (DataType) validator.validateAttribute(row, realmName).get(DataType.class);
 
 		Attribute attribute;
 		try {
@@ -211,13 +199,11 @@ public class GoogleSheetBuilder {
 		} catch(ItemNotFoundException e) {
 			log.trace("[!] Creating new Attribute: " + code);
 			// create new attribute if not found
-			attribute = new Attribute();
-			attribute.setCode(code);
-			attribute.setName(name);
+			attribute = new Attribute(code, name);
 		}
-		boolean privacy = toBoolean(row.get("privacy"));
+		boolean privacy = Boolean.parseBoolean(row.get("privacy"));
 		
-		attribute.setDttCode(row.get("datatype"));
+		attribute.setDttCode(datatype.getDttCode());
         attribute.setDefaultPrivacyFlag(privacy);
         attribute.setDescription(row.get("description"));
         attribute.setHelp(row.get("help"));
@@ -267,12 +253,12 @@ public class GoogleSheetBuilder {
         Integer valueInt = toInt(row.get(VALUEINTEGER));
         Long valueLong = toLong(row.get(VALUELONG));
         Double valueDouble = toDouble(row.get(VALUEDOUBLE));
-        boolean valueBoolean = toBoolean(row.get(VALUEBOOLEAN));
+        boolean valueBoolean = Boolean.parseBoolean(row.get(VALUEBOOLEAN));
 
         Double weight = toDouble(row.get(WEIGHT));
 
-        boolean privacy = toBoolean(row.get(PRIVACY));
-        boolean confirmation = toBoolean(row.get(CONFIRMATION));
+        boolean privacy = Boolean.parseBoolean(row.get(PRIVACY));
+        boolean confirmation = Boolean.parseBoolean(row.get(CONFIRMATION));
 
 		entityAttribute.setValueString(valueString);
 		entityAttribute.setValueInteger(valueInt);
@@ -310,8 +296,8 @@ public class GoogleSheetBuilder {
         String name = row.get("name");
         String html = row.get("html");
         String placeholder = row.get("placeholder");
-        boolean readonly = toBoolean(row.get(READONLY));
-        boolean mandatory = toBoolean(row.get(MANDATORY));
+        boolean readonly = Boolean.parseBoolean(row.get(READONLY));
+        boolean mandatory = Boolean.parseBoolean(row.get(MANDATORY));
         String icon = row.get("icon");
 
 		question.setName(name);
@@ -340,12 +326,12 @@ public class GoogleSheetBuilder {
 		Question child = (Question) dependencies.get(Validator.KEY_CHILD);
 
         Double weight = toDouble(row.get(WEIGHT));
-        boolean mandatory = toBoolean(row.get(MANDATORY));
-        boolean readonly = toBoolean(row.get(READONLY));
+        boolean mandatory = Boolean.parseBoolean(row.get(MANDATORY));
+        boolean readonly = Boolean.parseBoolean(row.get(READONLY));
 
         String icon = row.get("icon");
-        boolean disabled = toBoolean(row.get("disabled"));
-        boolean hidden = toBoolean(row.get("hidden"));
+        boolean disabled = Boolean.parseBoolean(row.get("disabled"));
+        boolean hidden = Boolean.parseBoolean(row.get("hidden"));
 
 		QuestionQuestion questionQuestion = new QuestionQuestion();
 		questionQuestion.setParentCode(parent.getCode());

--- a/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
@@ -56,7 +56,6 @@ import life.genny.qwandaq.exception.runtime.DebugException;
 import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
 import life.genny.qwandaq.exception.runtime.NullParameterException;
 import life.genny.qwandaq.exception.runtime.QueryBuilderException;
-import life.genny.qwandaq.managers.CacheManager;
 import life.genny.qwandaq.models.ANSIColour;
 import life.genny.qwandaq.models.Page;
 import life.genny.qwandaq.models.UserToken;
@@ -74,9 +73,6 @@ public class FyodorUltra {
 
 	@Inject
 	EntityManager entityManager;
-
-	@Inject
-	private CacheManager cm;
 
 	@Inject
 	BaseEntityUtils beUtils;
@@ -113,6 +109,7 @@ public class FyodorUltra {
 		for (BaseEntity baseEntity : page.getItems()) {
 			baseEntity.setIndex(index);
 			beUtils.addNonLiteralAttributes(baseEntity);
+			List<String[]> missedCodes = new ArrayList<>(allowed.size());
 			for (String attributeCode : allowed) {
 				EntityAttribute ea = null;
 				if (attributeCode.startsWith("_")) {
@@ -142,13 +139,19 @@ public class FyodorUltra {
 						try {
 							ea = beaUtils.getEntityAttribute(baseEntity.getRealm(), baseEntity.getCode(), attributeCode, true, true);
 						} catch (ItemNotFoundException e) {
-							log.trace(e.getMessage());
+							missedCodes.add(new String[] {attributeCode, e.getMessage()});
 						}
 					}
 				}
 				if (ea != null) {
 					baseEntity.addAttribute(ea);
-				}
+				} else 
+					missedCodes.add(new String[] {attributeCode, "Entity Attribute is null after processing"});
+			}
+
+			if(!missedCodes.isEmpty() && log.isTraceEnabled()) {
+				String missedCodeStr = CommonUtils.getArrayString(missedCodes, (code) -> code[0]);
+				log.trace("Could not find in BE: " + baseEntity.getCode() + ": " + missedCodeStr);
 			}
 		}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/constants/Prefix.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/constants/Prefix.java
@@ -38,7 +38,6 @@ public class Prefix {
 
 	// capability
 	public static final String CAP_ = "CAP_";
-	public static final String PRM_ = "PRM_";
 
 	// search entity
 	public static final String SBE_ = "SBE_";

--- a/qwandaq/src/main/java/life/genny/qwandaq/converter/CapabilityConverter.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/converter/CapabilityConverter.java
@@ -15,6 +15,7 @@ import life.genny.qwandaq.datatype.capability.core.Capability;
 import life.genny.qwandaq.datatype.capability.core.node.CapabilityNode;
 import life.genny.qwandaq.exception.runtime.BadDataException;
 import life.genny.qwandaq.managers.capabilities.CapabilitiesManager;
+import life.genny.qwandaq.utils.CommonUtils;
 
 public class CapabilityConverter implements AttributeConverter<Set<Capability>, String> {
     private static final Logger log = Logger.getLogger(CapabilityConverter.class);
@@ -78,6 +79,6 @@ public class CapabilityConverter implements AttributeConverter<Set<Capability>, 
     }
 
     private static StringBuilder serializeOneCapability(StringBuilder sb, Capability capability) {
-        return sb.append(capability.code).append(CapabilitiesManager.getModeString(capability.nodes));
+        return sb.append(capability.code).append(CommonUtils.getArrayString(capability.nodes));
     }
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/data/GennyCache.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/data/GennyCache.java
@@ -263,7 +263,7 @@ public class GennyCache {
 				sb.append(ANSIColour.doColour(stack.toString(), ANSIColour.RED))
 					.append('\n');
 			}
-			log.error(sb.toString());
+			log.trace(sb.toString());
 			throw e;
 		}
 		

--- a/qwandaq/src/main/java/life/genny/qwandaq/datatype/DataType.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/datatype/DataType.java
@@ -71,6 +71,7 @@ public class DataType implements CoreEntityPersistable {
 
 	public static final String DTT_LINK = "LNK_ATTRIBUTE"; // This datatype classname indicates the datatype belongs to
 															// the BaseEntity set with parent
+	public static final String DTT_CAPABILITY = "DTT_CAPABILITY";
 
 	@NotNull
 	@Size(max = 120)

--- a/qwandaq/src/main/java/life/genny/qwandaq/datatype/capability/core/CapabilityBuilder.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/datatype/capability/core/CapabilityBuilder.java
@@ -183,12 +183,11 @@ public class CapabilityBuilder {
         // TODO: add negate to rolebuilder
         if(roleBuilder == null)
             throw new UnsupportedOperationException("Cannot call build() on a CapabilityBuilder that was instantiated with new CapabilityBuilder(String code). Use .buildCap() instead");
-        roleBuilder.getCapabilities().put(capabilityCode, nodes.toArray(new CapabilityNode[0]));
+        roleBuilder.getCapabilities().put(capabilityCode, buildCap());
         return roleBuilder;
     }
 
     public Capability buildCap() {
-        Capability c = new Capability(capabilityCode, nodes);
-        return c;
+        return new Capability(capabilityCode, nodes);
     }
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/exception/runtime/ItemNotFoundException.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/exception/runtime/ItemNotFoundException.java
@@ -9,15 +9,19 @@ import life.genny.qwandaq.exception.GennyRuntimeException;
  */
 public class ItemNotFoundException extends GennyRuntimeException {
 
-	static String ERR_TEXT = "%s could not be found";
-	static String PRD_TXT = ERR_TEXT + " in product %s";
+	public static final String ERR_TEXT = "%s could not be found";
+	public static final String PRD_TXT = ERR_TEXT + " in product %s";
 
 	public ItemNotFoundException() {
 		super();
 	}
 
 	public ItemNotFoundException(String code) {
-		super(String.format(ERR_TEXT, code));
+		this(code, true);
+	}
+
+	public ItemNotFoundException(String code, boolean useFormat) {
+		super(useFormat ? String.format(ERR_TEXT, code) : code);
 	}
 
 	public ItemNotFoundException(String productCode, String code) {
@@ -25,7 +29,11 @@ public class ItemNotFoundException extends GennyRuntimeException {
 	}
 	
 	public ItemNotFoundException(String code, Throwable err) {
-		super(String.format(ERR_TEXT, code), err);
+		this(code, err, true);
+	}
+
+	public ItemNotFoundException(String code, Throwable err, boolean useFormat) {
+		super(useFormat ? String.format(ERR_TEXT, code) : code, err);
 	}
 
 	public ItemNotFoundException(String productCode, String code, Throwable err) {
@@ -34,5 +42,30 @@ public class ItemNotFoundException extends GennyRuntimeException {
 
 	public ItemNotFoundException(String productCode, String baseEntityCode, String attributeCode) {
 		super(String.format(PRD_TXT, "[" + baseEntityCode + ":" + attributeCode + "]", productCode));
+	}
+
+	/**
+	 * Generate a plain ItemNotFoundException without using the predefined format.
+	 * @param errorMsg - the details of this exception
+	 * @param cause - the cause of this Exception
+	 * @return a new unformatted ItemNotFoundException
+	 * 
+	 * @see {@link ItemNotFoundException#ERR_TEXT}
+	 * @see {@link ItemNotFoundException#PRD_TXT}
+	 */
+	public static ItemNotFoundException general(String errorMsg, Throwable cause) {
+		return new ItemNotFoundException(errorMsg, cause, false);
+	}
+
+	/**
+	 * Generate a plain ItemNotFoundException without using the predefined format.
+	 * @param errorMsg - the details of this exception
+	 * @return a new unformatted ItemNotFoundException
+	 * 
+	 * @see {@link ItemNotFoundException#ERR_TEXT}
+	 * @see {@link ItemNotFoundException#PRD_TXT}
+	 */
+	public static ItemNotFoundException general(String errorMsg) {
+		return new ItemNotFoundException(errorMsg, false);
 	}
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
@@ -380,13 +380,6 @@ public class CapabilitiesManager extends Manager {
 
 		filterable.setCapabilityRequirements(capabilityRequirements);
 
-		// TODO: Turn this into a sustainable solution
-
-		if(filterable instanceof HBaseEntity be) {
-			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to BaseEntity: " + realm + ":" + be.getCode());
-			beUtils.updateBaseEntity(be.toBaseEntity());
-			return true;
-		}
 
 		if(filterable instanceof QuestionQuestion qq) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to QuestionQuestion: " + realm + ":" + qq.getParentCode() + ":" + qq.getChildCode());
@@ -399,7 +392,15 @@ public class CapabilitiesManager extends Manager {
 			return questionUtils.saveQuestion(q);
 		}
 
-		if(filterable instanceof HEntityAttribute ea) {
+		// TODO: Turn this into a sustainable solution
+
+		if(filterable instanceof BaseEntity be) {
+			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to BaseEntity: " + realm + ":" + be.getCode());
+			beUtils.updateBaseEntity(be.toBaseEntity());
+			return true;
+		}
+
+		if(filterable instanceof EntityAttribute ea) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to EntityAttribute: " + realm + ":" + ea.getBaseEntityCode() + ":" + ea.getAttributeCode());
 			HBaseEntity be = ea.getBaseEntity();
 			beUtils.updateBaseEntity(be.toBaseEntity());

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
@@ -380,6 +380,10 @@ public class CapabilitiesManager extends Manager {
 
 		filterable.setCapabilityRequirements(capabilityRequirements);
 
+		if(filterable instanceof Question q) {
+			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to Question: " + realm + ":" + q.getCode());
+			return questionUtils.saveQuestion(q);
+		}
 
 		if(filterable instanceof QuestionQuestion qq) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to QuestionQuestion: " + realm + ":" + qq.getParentCode() + ":" + qq.getChildCode());
@@ -387,23 +391,17 @@ public class CapabilitiesManager extends Manager {
 			return questionUtils.saveQuestionQuestion(qq);
 		}
 
-		if(filterable instanceof Question q) {
-			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to Question: " + realm + ":" + q.getCode());
-			return questionUtils.saveQuestion(q);
-		}
-
 		// TODO: Turn this into a sustainable solution
 
 		if(filterable instanceof BaseEntity be) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to BaseEntity: " + realm + ":" + be.getCode());
-			beUtils.updateBaseEntity(be.toBaseEntity());
+			beUtils.updateBaseEntity(be);
 			return true;
 		}
 
 		if(filterable instanceof EntityAttribute ea) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to EntityAttribute: " + realm + ":" + ea.getBaseEntityCode() + ":" + ea.getAttributeCode());
-			HBaseEntity be = ea.getBaseEntity();
-			beUtils.updateBaseEntity(be.toBaseEntity());
+			beaUtils.updateEntityAttribute(ea);
 			return true;
 		}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
@@ -1,7 +1,6 @@
 package life.genny.qwandaq.managers.capabilities;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -71,9 +70,11 @@ public class CapabilitiesManager extends Manager {
 			log.warn("[Capabilities] Got null target for capability set compilation. Returning blank capabilities");
 			return new CapabilitySet(target);
 		}
-		if(!ACCEPTED_PREFIXES.contains(target.getCode().substring(0, 4)))
-			throw new RoleException(ANSIColour.doColour(target.getCode() + " IS NOT A CAPABILITY BEARING BASE ENTITY. PLEASE USE ANYTHING WITH THE FOLLOWING PREFIXES: " + CommonUtils.getArrayString(ACCEPTED_PREFIXES), ANSIColour.RED));
-// this is a necessary log, since we are trying to minimize how often this
+		
+		
+		validateTarget(target);
+		
+		// this is a necessary log, since we are trying to minimize how often this
 		// function is called
 		// it is good to see how often it comes up
 		log.debug("[!][!] Generating new User Capabilities for " + userToken.getUserCode());
@@ -138,8 +139,10 @@ public class CapabilitiesManager extends Manager {
 	 * @return
 	 */
 	public CapabilitySet getEntityCapabilities(final BaseEntity target) {
+		validateTarget(target);
+
 		Set<EntityAttribute> capabilities = new HashSet<>(beaUtils.getBaseEntityAttributesForBaseEntityWithAttributeCodePrefix(target.getRealm(), target.getCode(), Prefix.CAP_));
-		log.debug("		- " + target.getCode() + "(" + capabilities.size() + " capabilities)");
+		log.debug("\t- " + target.getCode() + "(" + capabilities.size() + " capabilities)");
 		if(capabilities.isEmpty()) {
 			return new CapabilitySet(target);
 		}
@@ -147,7 +150,7 @@ public class CapabilitiesManager extends Manager {
 		cSet.addAll(capabilities.stream()
 			.filter(ea -> ea != null)
 			.map((EntityAttribute ea) -> {
-				log.trace("	[!] " + ea.getAttributeCode() + " = " + ea.getValueString());
+				log.trace("\t[!] " + ea.getAttributeCode() + " = " + ea.getValueString());
 				return Capability.getFromEA(ea);
 			})
 			.collect(Collectors.toSet()));
@@ -162,23 +165,15 @@ public class CapabilitiesManager extends Manager {
 	 * @param capability        The capability attribute
 	 * @param nodes       The nodes to set
 	 */
-	private void updateCapability(String productCode, BaseEntity target, final Attribute capability,
+	private void updateCapability(BaseEntity target, final Attribute capability,
 			final CapabilityNode... nodes) {
-		// Update base entity
-		if (capability == null) {
-			throw new NullParameterException("capability");
-		}
+		validateTarget(target);
 
-		if (target == null) {
-			throw new NullParameterException("target");
-		}
-
-		EntityAttribute addedAttribute = target.addAttribute(capability, 0.0, getModeString(nodes));
+		EntityAttribute addedAttribute = target.addAttribute(capability, 0.0, CommonUtils.getArrayString(nodes));
 		beaUtils.updateEntityAttribute(addedAttribute);
-		beUtils.updateBaseEntity(target);
 	}
 
-	private void updateCapability(String productCode, BaseEntity target, final Attribute capability,
+	private void updateCapability(BaseEntity target, final Attribute capability,
 			final List<CapabilityNode> modeList) {
 		// Update base entity
 		if (capability == null) {
@@ -189,57 +184,58 @@ public class CapabilitiesManager extends Manager {
 			throw new NullParameterException("target");
 		}
 
-		EntityAttribute addedAttribute = target.addAttribute(capability, 0.0, getModeString(modeList));
+		EntityAttribute addedAttribute = target.addAttribute(capability, 0.0, CommonUtils.getArrayString(modeList));
 		beaUtils.updateEntityAttribute(addedAttribute);
 		beUtils.updateBaseEntity(target);
+	}
+
+	/**
+	 * Validate whether or not a given target can accept capabilities as entity attributes
+	 * @param target - the target base entity
+	 * @throws RoleException if the target is not a valid base entity
+	 */
+	private void validateTarget(BaseEntity target) throws RoleException {
+		validateTargetCode(target.getCode());
+	}
+
+	/**
+	 * Validate whether or not a given target code can accept capabilities as entity attributes
+	 * @param targetCode - the code of the target base entity
+	 * @throws RoleException if the target is not a valid base entity
+	 */
+	private void validateTargetCode(String targetCode) 
+		throws RoleException {
+		// This feels pretty primitive and can be amplified with BFS later if necessary.
+		// If this begins to break (e.g more prefixes are needed we can move to LNK_INCLUDE quite easily)
+		if(!ACCEPTED_PREFIXES.contains(targetCode.substring(0, 4)))
+			throw new RoleException(ANSIColour.doColour(targetCode + " IS NOT A CAPABILITY BEARING BASE ENTITY. PLEASE USE ANYTHING WITH THE FOLLOWING PREFIXES: " + CommonUtils.getArrayString(ACCEPTED_PREFIXES), ANSIColour.RED));
 	}
 
 	public Attribute createCapability(final String productCode, final String rawCapabilityCode, final String name) {
 		return createCapability(productCode, rawCapabilityCode, name, false);
 	}
 
+	/**
+	 * Create a new Capability Attribute
+	 * @param productCode - the product to store it in
+	 * @param rawCapabilityCode - the (potentially unrefined) capability code
+	 * @param name - the name of the capability
+	 * @param cleanedCode - whether or not the rawCapabilityCode has already been system cleaned (false as default)
+	 * @return the new (saved) capability attribute if it doesn't already exit
+	 * @throws ItemNotFoundException - if the {@link DataType#DTT_CAPABILITY DTT_CAPABILITY} does not exist in the supplied product
+	 */
 	public Attribute createCapability(final String productCode, final String rawCapabilityCode, final String name,
-			boolean cleanedCode) {
+			boolean cleanedCode) throws ItemNotFoundException {
 		String cleanCapabilityCode = cleanedCode ? rawCapabilityCode : cleanCapabilityCode(rawCapabilityCode);
-		Attribute attribute = null;
-		try {
-			attribute = attributeUtils.getAttribute(productCode, cleanCapabilityCode, true);
-		} catch(ItemNotFoundException e) {
-			log.debug("Could not find Attribute: " + cleanCapabilityCode + ". Creating new Capability");
-		}
 
-		if (attribute == null) {
-			log.trace("Creating Capability : " + cleanCapabilityCode + " : " + name);
-			attribute = new Attribute(cleanCapabilityCode, name, new DataType(String.class));
-			attribute.setRealm(productCode);
-			attributeUtils.saveAttribute(attribute);
-		}
-
-		return attribute;
+		DataType capabilityDtt = attributeUtils.getDataType(productCode, DataType.DTT_CAPABILITY, true);
+		return attributeUtils.getOrCreateAttribute(productCode, cleanCapabilityCode, capabilityDtt);
 	}
 
-	public BaseEntity addCapabilityToBaseEntity(String productCode, BaseEntity targetBe, Attribute capabilityAttribute,
+	public BaseEntity addCapabilityToBaseEntity(BaseEntity targetBe, Attribute capabilityAttribute,
 			final CapabilityNode... modes) {
-		if (capabilityAttribute == null) {
-			throw new ItemNotFoundException(productCode, "Capability Attribute");
-		}
 
-		// Check the user token has required capabilities
-		// if (!shouldOverride()) {
-		// 	log.error(userToken.getUserCode() + " is NOT ALLOWED TO ADD CAP: " + capabilityAttribute.getCode()
-		// 			+ " TO BASE ENTITITY: " + targetBe.getCode());
-		// 	return targetBe;
-		// }
-
-		// ===== Old capability check ===
-		// if (!hasCapability(cleanCapabilityCode, true, modes)) {
-		// log.error(userToken.getUserCode() + " is NOT ALLOWED TO ADD CAP: " +
-		// cleanCapabilityCode
-		// + " TO BASE ENTITITY: " + targetBe.getCode());
-		// return targetBe;
-		// }
-
-		updateCapability(productCode, targetBe, capabilityAttribute, modes);
+		updateCapability(targetBe, capabilityAttribute, modes);
 		return targetBe;
 	}
 
@@ -261,28 +257,17 @@ public class CapabilitiesManager extends Manager {
 		return targetBe;
 	}
 
+	public BaseEntity addCapabilityToBaseEntity(BaseEntity targetBe, Capability capability) {
+		return addCapabilityToBaseEntity(targetBe.getRealm(), targetBe, capability.code, capability.nodes.toArray(new CapabilityNode[0]));
+	}
+
 	public BaseEntity addCapabilityToBaseEntity(String productCode, BaseEntity targetBe, Attribute capabilityAttribute,
 			final List<CapabilityNode> modes) {
 		if (capabilityAttribute == null) {
 			throw new ItemNotFoundException(productCode, "Capability Attribute");
 		}
 
-		// Check the user token has required capabilities
-		// if (!shouldOverride()) {
-		// 	log.error(userToken.getUserCode() + " is NOT ALLOWED TO ADD CAP: " + capabilityAttribute.getCode()
-		// 			+ " TO BASE ENTITITY: " + targetBe.getCode());
-		// 	return targetBe;
-		// }
-
-		// ===== Old capability check ===
-		// if (!hasCapability(cleanCapabilityCode, true, modes)) {
-		// log.error(userToken.getUserCode() + " is NOT ALLOWED TO ADD CAP: " +
-		// cleanCapabilityCode
-		// + " TO BASE ENTITITY: " + targetBe.getCode());
-		// return targetBe;
-		// }
-
-		updateCapability(productCode, targetBe, capabilityAttribute, modes);
+		updateCapability(targetBe, capabilityAttribute, modes);
 		return targetBe;
 	}
 
@@ -294,7 +279,7 @@ public class CapabilitiesManager extends Manager {
 		// Don't need to catch here since we don't want to create
 		Attribute attribute = attributeUtils.getAttribute(productCode, cleanCapabilityCode, true);
 
-		return addCapabilityToBaseEntity(productCode, targetBe, attribute, modes);
+		return addCapabilityToBaseEntity(targetBe, attribute, modes);
 	}
 
 	public BaseEntity addCapabilityToBaseEntity(String productCode, BaseEntity target, final String rawCapCode,
@@ -377,25 +362,6 @@ public class CapabilitiesManager extends Manager {
 		return capabilityMap;
 	}
 
-	/**
-	 * Serialize an array of {@link CapabilityNode}s to a string
-	 * 
-	 * @param capabilities
-	 * @return
-	 */
-	public static String getModeString(CapabilityNode... capabilities) {
-		return CommonUtils.getArrayString(capabilities, (capability) -> capability.toString());
-	}
-
-	public static String getModeString(Collection<CapabilityNode> capabilities) {
-		return CommonUtils.getArrayString(capabilities, (capability) -> capability.toString());
-	}
-
-	private boolean shouldOverride() {
-		// allow keycloak admin and devcs to do anything
-		return (userToken.hasRole("service", "admin", "dev") || ("service".equals(userToken.getUsername())));
-	}
-
 	// For use in builder patterns
 	public RoleManager getRoleManager() {
 		return roleMan;
@@ -416,33 +382,31 @@ public class CapabilitiesManager extends Manager {
 
 		// TODO: Turn this into a sustainable solution
 
-		if(filterable instanceof HBaseEntity) {
-			HBaseEntity be = (HBaseEntity)filterable;
+		if(filterable instanceof HBaseEntity be) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to BaseEntity: " + realm + ":" + be.getCode());
 			beUtils.updateBaseEntity(be.toBaseEntity());
 			return true;
 		}
 
-		if(filterable instanceof QuestionQuestion) {
-			QuestionQuestion qq = (QuestionQuestion)filterable;
+		if(filterable instanceof QuestionQuestion qq) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to QuestionQuestion: " + realm + ":" + qq.getParentCode() + ":" + qq.getChildCode());
 			// TODO: Potentially update sub questions
 			return questionUtils.saveQuestionQuestion(qq);
 		}
 
-		if(filterable instanceof Question) {
-			Question q = (Question)filterable;
+		if(filterable instanceof Question q) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to Question: " + realm + ":" + q.getCode());
 			return questionUtils.saveQuestion(q);
 		}
 
-		if(filterable instanceof HEntityAttribute) {
-			HEntityAttribute ea = (HEntityAttribute)filterable;
+		if(filterable instanceof HEntityAttribute ea) {
 			log.info("Attaching Capability Requirements: " + CommonUtils.getArrayString(capabilityRequirements) + " to EntityAttribute: " + realm + ":" + ea.getBaseEntityCode() + ":" + ea.getAttributeCode());
 			HBaseEntity be = ea.getBaseEntity();
 			beUtils.updateBaseEntity(be.toBaseEntity());
 			return true;
 		}
+
+		log.error("Unhandled filterable: " + filterable.getClass());
 		return false;
 	}
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleBuilder.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleBuilder.java
@@ -11,8 +11,8 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.arc.Arc;
 import life.genny.qwandaq.attribute.Attribute;
+import life.genny.qwandaq.datatype.capability.core.Capability;
 import life.genny.qwandaq.datatype.capability.core.CapabilityBuilder;
-import life.genny.qwandaq.datatype.capability.core.node.CapabilityNode;
 import life.genny.qwandaq.entity.BaseEntity;
 import life.genny.qwandaq.exception.checked.RoleException;
 import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
@@ -40,12 +40,10 @@ public class RoleBuilder {
     /**
      * A map from Capability Code to Capabilities to add to the role for that Capability
      */
-    private Map<String, CapabilityNode[]> roleCapabilities = new HashMap<>();
+    private Map<String, Capability> roleCapabilities = new HashMap<>();
 
     private String redirectCode;
 
-    // TODO: Again I want to get rid of product code chains like this
-    // TODO: Hopefully we can firm up how product codes are assigned to tokens
     public RoleBuilder(String roleCode, String roleName, String productCode) {
         this.capManager = Arc.container().select(CapabilitiesManager.class).get();
         this.roleMan = capManager.getRoleManager();
@@ -114,7 +112,7 @@ public class RoleBuilder {
         return this;
     }
 
-    public Map<String, CapabilityNode[]> getCapabilities() {
+    public Map<String, Capability> getCapabilities() {
         return roleCapabilities;
     }
 
@@ -128,7 +126,7 @@ public class RoleBuilder {
 
         // Capabilities
         for(String capabilityCode : roleCapabilities.keySet()) {
-            capManager.addCapabilityToBaseEntity(productCode, targetRole, fetch(capabilityCode), roleCapabilities.get(capabilityCode));
+            capManager.addCapabilityToBaseEntity(targetRole, roleCapabilities.get(capabilityCode));
         }
         
         // Role inherits

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -90,7 +90,7 @@ public class RoleManager extends Manager {
 
 		EntityAttribute children;
 		try {
-			children = beaUtils.getEntityAttribute(productCode, targetRole.getCode(), Attribute.LNK_CHILDREN, true, true);
+			children = beaUtils.getEntityAttribute(productCode, targetRole.getCode(), Attribute.LNK_CHILDREN);
 			children.setValueString(CommonUtils.getArrayString(childrenCodes));
 		} catch(ItemNotFoundException e) {
 			log.warn("LNK_CHILDREN missing from role: " + targetRole.getCode() + ". Generating with children: " + CommonUtils.getArrayString(childrenCodes));

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -3,18 +3,14 @@ package life.genny.qwandaq.managers.capabilities.role;
 import life.genny.qwandaq.attribute.Attribute;
 import life.genny.qwandaq.attribute.EntityAttribute;
 import life.genny.qwandaq.constants.Prefix;
-import life.genny.qwandaq.datatype.DataType;
 import life.genny.qwandaq.datatype.capability.core.node.CapabilityNode;
 import life.genny.qwandaq.entity.BaseEntity;
 import life.genny.qwandaq.exception.checked.RoleException;
 import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
 import life.genny.qwandaq.exception.runtime.NullParameterException;
-import life.genny.qwandaq.managers.CacheManager;
 import life.genny.qwandaq.managers.Manager;
 import life.genny.qwandaq.managers.capabilities.CapabilitiesManager;
-import life.genny.qwandaq.utils.AttributeUtils;
 import life.genny.qwandaq.utils.CommonUtils;
-import life.genny.qwandaq.utils.EntityAttributeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
@@ -30,26 +26,10 @@ public class RoleManager extends Manager {
 	Logger log;
 
 	@Inject
-	AttributeUtils attributeUtils;
-
-	private final static AttributeProductDecorator lnkRoleAttribute = new AttributeProductDecorator(
-		new Attribute(Attribute.LNK_ROLE, "Role Link", new DataType(String.class))
-	);
-	
-	private final static AttributeProductDecorator lnkChildAttribute = new AttributeProductDecorator(
-		new Attribute(Attribute.LNK_CHILDREN, "Child Roles Link", new DataType(String.class))
-	);
-
-	@Inject
-	CacheManager cm;
-
-	@Inject
 	CapabilitiesManager capManager;
 
-	@Inject
-	EntityAttributeUtils beaUtils;
+	public RoleManager() {/* no arg constructor */}
 
-	public RoleManager() {}
     
 	/**
 	 * Attach a role to a person base entity
@@ -106,22 +86,19 @@ public class RoleManager extends Manager {
 	public BaseEntity setChildren(String productCode, BaseEntity targetRole, String... childrenCodes) {
 		if (targetRole == null)
 			throw new NullParameterException("targetRole");
-		String attributeCode = lnkChildAttribute.get(productCode).getCode();
-		EntityAttribute children = beaUtils.getEntityAttribute(productCode, targetRole.getCode(), attributeCode, true, true);
-		String codeString = CommonUtils.getArrayString(childrenCodes);
 
-		// add/edit LNK_CHILDREN
-		if(children == null) {
-			EntityAttribute addedAttribute = targetRole.addAttribute(lnkChildAttribute.get(productCode), 1.0, codeString);
-			beaUtils.updateEntityAttribute(addedAttribute);
-		} else {
-			children.setAttribute(attributeUtils.getAttribute(productCode, attributeCode, true));
-			children.setValue(codeString);
-			beaUtils.updateEntityAttribute(children);
+
+		EntityAttribute children;
+		try {
+			children = beaUtils.getEntityAttribute(productCode, targetRole.getCode(), Attribute.LNK_CHILDREN, true, true);
+			children.setValueString(CommonUtils.getArrayString(childrenCodes));
+		} catch(ItemNotFoundException e) {
+			log.warn("LNK_CHILDREN missing from role: " + targetRole.getCode() + ". Generating with children: " + CommonUtils.getArrayString(childrenCodes));
+			// If LNK_CHILDREN can't be found we have bigger problems. Check sheets if missing
+			Attribute lnkChildren = attributeUtils.getAttribute(productCode, Attribute.LNK_CHILDREN, true);
+			children = targetRole.addAttribute(lnkChildren, 0.0, CommonUtils.getArrayString(childrenCodes));
 		}
-
-		// TODO: Keep an eye on this because it may have just broken
-		beUtils.updateBaseEntity(targetRole);
+		beaUtils.updateEntityAttribute(children);
 		return targetRole;
 	}
 
@@ -136,26 +113,19 @@ public class RoleManager extends Manager {
 		if(targetRole == null)
 			throw new NullParameterException("targetRole");
 
-		EntityAttribute children = beaUtils.getEntityAttribute(productCode, targetRole.getCode(), Attribute.LNK_CHILDREN);
+		String newChildren = "";
 
-		List<String> childrenCodeList = Arrays.asList(childrenCodes);
-		Attribute attribute = lnkChildAttribute.get(productCode);
-		// add/edit LNK_CHILDREN
-		if(children == null) {
-			children = targetRole.addAttribute(attribute, 1.0);
-		} else {
-			children.setAttribute(attribute);
-			String[] preexistingChildren = CommonUtils.cleanUpAttributeValue(children.getValueString()).split(",");
-			childrenCodeList.addAll(Arrays.asList(preexistingChildren));
+		// make an attempt to grab pre existing children
+		try {
+			EntityAttribute children = beaUtils.getEntityAttribute(productCode, targetRole.getCode(), Attribute.LNK_CHILDREN);
+			newChildren = children.getValueString();
+		} catch(ItemNotFoundException e) {
+			log.warn("No Children previously set for role: " + targetRole.getCode());
 		}
 
-		String codeString = CommonUtils.getArrayString(childrenCodeList);
-		children.setValue(codeString);
+		newChildren = CommonUtils.addToStringArray(newChildren, childrenCodes);
 
-		// TODO: Keep an eye on this becasue it may have just broken
-		beUtils.updateBaseEntity(targetRole);
-		beaUtils.updateEntityAttribute(children);
-		return targetRole;
+		return setChildren(productCode, targetRole, newChildren);
 	}
 
 	/**
@@ -319,20 +289,20 @@ public class RoleManager extends Manager {
 
 	public BaseEntity attachRole(BaseEntity target, BaseEntity role) {
 		String productCode = target.getRealm();
-		EntityAttribute baseEntityAttribute = beaUtils.getEntityAttribute(productCode, target.getCode(), Attribute.LNK_ROLE, true, true);
-		// Create it
-		if (baseEntityAttribute == null) {
-			baseEntityAttribute = target.addAttribute(lnkRoleAttribute.get(productCode), 1.0, "[" + role.getCode() + "]");
-			beaUtils.updateEntityAttribute(baseEntityAttribute);
-			return target;
+
+		EntityAttribute targetLNKRole;
+		try {
+			targetLNKRole = beaUtils.getEntityAttribute(productCode, target.getCode(), Attribute.LNK_ROLE, true, true);
+		} catch(ItemNotFoundException e) {
+			Attribute lnkRoleAttrib = attributeUtils.getAttribute(productCode, Attribute.LNK_ROLE);
+			targetLNKRole = target.addAttribute(lnkRoleAttrib, 1.0, "[" + role.getCode() + "]");
 		}
 
-		String value = baseEntityAttribute.getValueString();
+		String value = targetLNKRole.getValueString();
 		value = CommonUtils.addToStringArray(value, role.getCode());
+		targetLNKRole.setValueString(value);
+		beaUtils.updateEntityAttribute(targetLNKRole);
 
-		baseEntityAttribute.setValueString(value);
-
-		beaUtils.updateEntityAttribute(baseEntityAttribute);
 		return target;
 	}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
@@ -177,6 +177,9 @@ public class CommonUtils {
      * @return a JSON style array of object
      */
     public static <T> String getArrayString(T[] arr) {
+        if(arr == null || arr.length == 0) {
+            return STR_ARRAY_EMPTY;
+        }
         return getArrayString(arr, (item) -> {
             return item != null ? item.toString() : "null";
         });

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/DefUtils.java
@@ -1,6 +1,5 @@
 package life.genny.qwandaq.utils;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -10,8 +9,6 @@ import javax.inject.Inject;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
-import life.genny.qwandaq.entity.search.trait.Ord;
-import life.genny.qwandaq.entity.search.trait.Sort;
 import org.jboss.logging.Logger;
 import life.genny.qwandaq.Answer;
 import life.genny.qwandaq.attribute.Attribute;
@@ -77,7 +74,7 @@ public class DefUtils {
 	@Inject
 	AttributeUtils attributeUtils;
 
-	public DefUtils() {
+	public DefUtils() { /* no-arg constructor */
 	}
 
 	/**
@@ -87,10 +84,11 @@ public class DefUtils {
 	 * @return BaseEntity The corresponding definition {@link BaseEntity}
 	 */
 	public Definition getDEF(final BaseEntity entity) {
-		entity.setBaseEntityAttributes(beaUtils.getAllEntityAttributesForBaseEntity(entity));
 
 		if (entity == null)
 			throw new NullParameterException("entity");
+
+		entity.setBaseEntityAttributes(beaUtils.getAllEntityAttributesForBaseEntity(entity));
 
 		// save processing time on particular entities
 		if (entity.getCode().startsWith(Prefix.DEF_))
@@ -188,7 +186,7 @@ public class DefUtils {
 	 * @param answer     the answer to check
 	 * @return Boolean
 	 */
-	public Boolean answerValidForDEF(Definition definition, Answer answer) {
+	public boolean answerValidForDEF(Definition definition, Answer answer) {
 
 		if (definition == null)
 			throw new NullParameterException("definition");
@@ -200,10 +198,8 @@ public class DefUtils {
 
 		// allow if it is Capability saved to a Role
 		// TODO: Make this nicer
-		// TODO: Get rid of PRM_ ????
-		if (targetCode.startsWith(Prefix.ROL_) && attributeCode.startsWith(Prefix.PRM_)) {
-			return true;
-		} else if (targetCode.startsWith(Prefix.SBE_) && (attributeCode.startsWith(Prefix.COL_)
+		boolean isCapabilities = targetCode.startsWith(Prefix.ROL_) && attributeCode.startsWith(Prefix.CAP_);
+		if (isCapabilities || targetCode.startsWith(Prefix.SBE_) && (attributeCode.startsWith(Prefix.COL_)
 				|| attributeCode.startsWith(Prefix.SRT_) || attributeCode.startsWith(Prefix.ACT_))) {
 			return true;
 		}
@@ -265,7 +261,7 @@ public class DefUtils {
 	 * @param acvs     the attribute code value to check
 	 * @return Boolean
 	 */
-	public Boolean attributeValueValidForDEF(BaseEntity defBE, AttributeCodeValueString acvs) {
+	public boolean attributeValueValidForDEF(BaseEntity defBE, AttributeCodeValueString acvs) {
 
 		if (defBE == null) {
 			throw new NullParameterException("defBE");
@@ -279,10 +275,7 @@ public class DefUtils {
 		if (attribute == null)
 			throw new NullParameterException("attribute");
 
-		// allow if it is Capability saved to a Role
-		if (defBE.getCode().equals("DEF_ROLE") && attribute.getCode().startsWith(Prefix.PRM_)) {
-			return true;
-		} else if (defBE.getCode().equals("DEF_SEARCH")
+		if (defBE.getCode().equals("DEF_SEARCH")
 				&& (attribute.getCode().startsWith(Prefix.COL_) 
 				|| attribute.getCode().startsWith(Prefix.SRT_) || attribute.getCode().startsWith(Prefix.ACT_))) {
 			return true;
@@ -296,8 +289,7 @@ public class DefUtils {
 		}
 
 		// Now do a value validation check
-		Boolean result = qwandaUtils.validationsAreMet(attribute, acvs.getValue());
-		return result;
+		return qwandaUtils.validationsAreMet(attribute, acvs.getValue());
 	}
 
 	/**
@@ -350,6 +342,8 @@ public class DefUtils {
 						if (mergeUtils.contextsArePresent(attrValStr, ctxMap)) {
 							// TODO: mergeUtils should be taking care of this bracket replacement - Jasper
 							// (6/08/2021)
+							// TODO: God I wish we had time to fix and test this - Bryn
+							// (17/03/2023)
 							Object mergedObj = mergeUtils.wordMerge(attrValStr.replace("[[", "").replace("]]", ""),
 									ctxMap);
 							// Ensure Datatype is Correct, then set Value

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
@@ -215,6 +215,8 @@ public class EntityAttributeUtils {
 	 * @param embedAttribute Defines if "Attribute" will be embedded into the
 	 *                       returned EntityAttribute
 	 * @return The corresponding BaseEntityAttribute, or null if not found.
+	 * 
+	 * @throws ItemNotFoundException if the requested EntityAttribute could not be found
 	 */
 	public EntityAttribute getEntityAttribute(String productCode, String baseEntityCode, String attributeCode,
 			boolean embedAttribute, boolean embedDataType) {

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/MergeUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/MergeUtils.java
@@ -13,6 +13,7 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 import life.genny.qwandaq.attribute.EntityAttribute;
 import life.genny.qwandaq.entity.BaseEntity;
@@ -115,7 +116,7 @@ public class MergeUtils {
 	 */
 	public Object wordMerge(String mergeText, Map<String, Object> entitymap) {
 
-		if (mergeText == null || mergeText.isEmpty())
+		if (StringUtils.isBlank(mergeText))
 			return DEFAULT;
 
 		// we split the text to merge into 2 components: BE.PRI... becomes [BE, PRI...]
@@ -227,7 +228,7 @@ public class MergeUtils {
 	* @param templateEntityMap the mergeStr to check contexts with
 	* @return Boolean
 	 */
-	public Boolean contextsArePresent(String mergeStr, Map<String, Object> templateEntityMap) {
+	public boolean contextsArePresent(String mergeStr, Map<String, Object> templateEntityMap) {
 		
 		if (mergeStr != null) {
 


### PR DESCRIPTION
* Detached Attributes are currently present in Capabilities System (legacy code, used to rely on Hibernate to manage ids). This is fixed now with a standardised way to create attributes that can be extended to bootq and other parts of the code if necessary
* Revised try/catch in FyodorUltra for missing rows. Can extend this to display the details of item not founds of every missed entity attribute for a row in a table
* Put on stricter validation for Capability-bearing base entities
* Removed some redundant methods and added some documentation

As a note we should strive to remove Object portrayals of primitives (Boolean instead of boolean, Integer instead of int etc) where possible. I understand this may not necessarily be possible for database fields but it is very possible for methods that return said primitives/objects