### PR TITLE
Resolve Field Clearing

### DIFF
--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -227,7 +227,7 @@ public class Dispatch {
 	 */
 	public void sendButtonEvents(Set<Ask> asks) {
 		for (Ask ask : asks) {
-			if (ask.getQuestionCode().equals(Question.QUE_EVENTS)) {
+			if (Question.QUE_EVENTS.equals(ask.getQuestionCode())) {
 				QDataAskMessage msg = new QDataAskMessage(ask);
 				msg.setReplace(true);
 				msg.setToken(userToken.getToken());

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -207,15 +207,33 @@ public class Dispatch {
 		// update any button Events
 		for (String event : BUTTON_EVENTS) {
 			Ask evt = flatMapOfAsks.get(event);
-			if (evt != null)
+			if (evt != null) {
 				evt.setDisabled(!answered);
+			}
 		}
+		sendButtonEvents(asks);
+
 		// this is ok since flatmap is referencing asks
 		msg.setAsks(asks);
 		// filter unwanted attributes
 		log.debug("ProcessEntity contains " + processEntity.getBaseEntityAttributesMap().size() + " attributes");
 
 		return processEntity;
+	}
+
+	/**
+	 * Send the button events
+	 * @param asks
+	 */
+	public void sendButtonEvents(Set<Ask> asks) {
+		for (Ask ask : asks) {
+			if (ask.getQuestionCode().equals(Question.QUE_EVENTS)) {
+				QDataAskMessage msg = new QDataAskMessage(ask);
+				msg.setReplace(true);
+				msg.setToken(userToken.getToken());
+				KafkaUtils.writeMsg(KafkaTopic.WEBCMDS, msg);
+			}
+		}
 	}
 
 	/**

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/TaskService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/TaskService.java
@@ -202,8 +202,6 @@ public class TaskService extends KogitoService {
 
 		//check duplicate records
 		if (!processAnswers.checkUniqueness(processData)) {
-			disableButtons(processData);
-
 			return processData;
 		}
 

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/TaskService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/TaskService.java
@@ -205,9 +205,6 @@ public class TaskService extends KogitoService {
 			return processData;
 		}
 
-		// send data to FE
-		dispatch.sendData(msg);
-
 		// update cached process data
 		qwandaUtils.storeProcessData(processData);
 
@@ -266,24 +263,4 @@ public class TaskService extends KogitoService {
 		navigationService.redirect();
 	}
 
-	/**
-	 * Disable buttons if it is not valid data
-	 * @param processData Process Data
-	 */
-	public void disableButtons(ProcessData processData) {
-		Set<Ask> asks = qwandaUtils.fetchAsks(processData);
-		Map<String, Ask> flatMapOfAsks = QwandaUtils.buildAskFlatMap(asks);
-
-		for (String event : Dispatch.BUTTON_EVENTS) {
-			Ask evt = flatMapOfAsks.get(event);
-			if (evt != null)
-				evt.setDisabled(true);
-		}
-
-		QDataAskMessage msg = new QDataAskMessage(asks);
-		msg.setReplace(true);
-		msg.setToken(userToken.getToken());
-
-		KafkaUtils.writeMsg(KafkaTopic.WEBCMDS, msg);
-	}
 }


### PR DESCRIPTION
Fields were clearing due to the entire set of asks being re-sent. This set of changes ensures we only send what is necessary at the time (Updates to buttons).