### PR TITLE
Forward AUTH_INIT

### DIFF
--- a/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
+++ b/kogitoq/gadaq/src/main/java/life/genny/gadaq/route/Events.java
@@ -110,7 +110,7 @@ public class Events {
         // auth init
         if (AUTH_INIT.equals(code)) {
             kogitoUtils.triggerWorkflow(SELF, "authInit", "userCode", userToken.getUserCode());
-            return;
+            // We may want services to enact something on auth init, so continue;
         }
 
         // submit, next and update


### PR DESCRIPTION
Forward AUTH_INIT to products to be handled. This provides the opportunity to perform product specific actions on auth init.