### PR TITLE
Fix PCMs referencing PCMs that have been filtered out due to capabilities in dispatch

### DIFF
--- a/bootq/src/main/java/life/genny/bootq/service/ImportService.java
+++ b/bootq/src/main/java/life/genny/bootq/service/ImportService.java
@@ -52,7 +52,7 @@ public class ImportService {
                 RealmUnit name = new RealmUnit(rawData);
                 list.add(name);
             } else {
-                log.warn("No RAW DATA");
+                log.warn("No RAW DATA from sheet uri: " + sheetURI);
             }
         }
         return list;

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -287,14 +287,15 @@ public class Dispatch {
 		// iterate locations
 		List<EntityAttribute> locations = beaUtils.getBaseEntityAttributesForBaseEntityWithAttributeCodePrefix(pcm.getRealm(), pcmCode, Prefix.PRI_LOC);
 
-		List<EntityAttribute> filteredLocations = new ArrayList<>(locations.size());
-		for (EntityAttribute entityAttribute : locations) {
-			if(!entityAttribute.requirementsMet(userCapabilities)) {
-				log.trace("capability requirements not met for location: " + entityAttribute.getAttributeCode() + " (" + entityAttribute.getValueString() + ")");
-				filteredLocations.add(entityAttribute);
-				continue;
+		locations.removeIf(loc -> {
+			if(!loc.requirementsMet(userCapabilities)) {
+				log.debug("capability requirements not met for location: " + loc.getAttributeCode() + " (" + loc.getValueString() + ")");
+				return true;
 			}
+			return false;
+		});
 
+		for (EntityAttribute entityAttribute : locations) {
 			log.debug("Passed Capabilities check for: " + entityAttribute.getBaseEntityCode() + ":" + entityAttribute.getAttributeCode());
 
 			Attribute attribute = attributeUtils.getAttribute(entityAttribute.getRealm(), entityAttribute.getAttributeCode(), true);
@@ -314,12 +315,6 @@ public class Dispatch {
 			} else if (value.startsWith(Prefix.SBE_)) {
 				processData.getSearches().add(value);
 			}
-		}
-
-		// ensure these don't go out to frontend
-		for(EntityAttribute badlocation : filteredLocations) {
-			log.debug("Removing: " + badlocation.getAttributeCode() + " from " + badlocation.getBaseEntityCode());
-			pcm.getBaseEntityAttributes().removeIf(loc -> loc.getAttributeCode().equals(badlocation.getAttributeCode()));
 		}
 
 		msg.add(pcm);

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -289,15 +289,17 @@ public class Dispatch {
 
 		log.debug("Locations size before: " + locations.size());
 		final Map<String, Integer> count = new HashMap<>();
-		locations.removeIf(loc -> {
+		count.put("key", 0);
+		boolean didRemove = locations.removeIf(loc -> {
 			if(!loc.requirementsMet(userCapabilities)) {
 				log.debug("capability requirements not met for location: " + loc.getAttributeCode() + " (" + loc.getValueString() + ")");
-				count.put("key", count.getOrDefault("key", 0) + 1);
+				count.put("key", count.get("key") + 1);
 				return true;
 			}
 			return false;
 		});
-
+		if(didRemove)
+			log.debug(" DID STUFF!");
 		log.debug("Locations size after: " + locations.size() + " .. Expected: " + count.get("key"));
 
 		for (EntityAttribute entityAttribute : locations) {

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -287,13 +287,18 @@ public class Dispatch {
 		// iterate locations
 		List<EntityAttribute> locations = beaUtils.getBaseEntityAttributesForBaseEntityWithAttributeCodePrefix(pcm.getRealm(), pcmCode, Prefix.PRI_LOC);
 
+		log.debug("Locations size before: " + locations.size());
+		final Map<String, Integer> count = new HashMap<>();
 		locations.removeIf(loc -> {
 			if(!loc.requirementsMet(userCapabilities)) {
 				log.debug("capability requirements not met for location: " + loc.getAttributeCode() + " (" + loc.getValueString() + ")");
+				count.put("key", count.getOrDefault("key", 0) + 1);
 				return true;
 			}
 			return false;
 		});
+
+		log.debug("Locations size after: " + locations.size() + " .. Expected: " + count.get("key"));
 
 		for (EntityAttribute entityAttribute : locations) {
 			log.debug("Passed Capabilities check for: " + entityAttribute.getBaseEntityCode() + ":" + entityAttribute.getAttributeCode());

--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/core/Dispatch.java
@@ -318,7 +318,7 @@ public class Dispatch {
 
 		// ensure these don't go out to frontend
 		for(EntityAttribute badlocation : filteredLocations) {
-			log.trace("Removing: " + badlocation.getAttributeCode() + " from " + badlocation.getBaseEntityCode());
+			log.debug("Removing: " + badlocation.getAttributeCode() + " from " + badlocation.getBaseEntityCode());
 			pcm.getBaseEntityAttributes().removeIf(loc -> loc.getAttributeCode().equals(badlocation.getAttributeCode()));
 		}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/attribute/EntityAttribute.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/attribute/EntityAttribute.java
@@ -886,6 +886,7 @@ public class EntityAttribute implements CoreEntityPersistable, ICapabilityHidden
 				return df2.format(date);
 			}
 		}
+
 		return getValueString();
 	}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/CommonUtils.java
@@ -466,6 +466,8 @@ public class CommonUtils {
 	 * @return A clean string
 	 */
     public static String cleanUpAttributeValue(String value) {
+        if(StringUtils.isBlank(value))
+            return "";
 		return value.replace("\"", "").replace("[", "").replace("]", "").replace(" ", "");
 	}
 


### PR DESCRIPTION
Previously, if a user did not meet the requirements for a PCM base entity it would not get sent out, but PCM EntityAttributes that are locations that reference that PCM base entity would. 

While this is fine for the majority of cases, it does present an issue for the more dynamic use of capabilities. If a summary gets sent out with `PCM A` that at that point time the user can see, and then the user's capabilities gets updated so that they should no longer be able to see `PCM A`, any PCMs that reference `PCM A` in their locations will still display `PCM A` due to caching within redux within Alyson. 

This does not make this a front end issue,  instead the solution is to filter out the locations within the PCM being traversed based on if the PCM that is being referenced by a given location can be seen by the user or not.

This solution relies on beUtils.getPCM defaulting to return all attributes (which at present it does). If this stops working that will be one point in the code to check.

If we didn't get the attributes when we fetched the PCM using beUtils.getPCM then we would have to continue using the second cache check and potentially have to iterate multiple times to remove bad locations that reference PCMs that the user shouldn't see, since we will technically have to maintain two lists during execution - one for the locations fetched from cache in the method call that has now been removed, and the other in the PCM base entity itself which gets added to the QBaseEntityMessage, EntityAttributes and all. It is more important that the latter case gets maintained, however maintaining the former case / removing the need for there to be two cases at all means there is a bit more speed in having to iterate less times, and through less things