### PR TITLE
GennyToken.getCode deprecation

### DIFF
--- a/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/CapabilityService.java
+++ b/kogitoq/kogito-common/src/main/java/life/genny/kogito/common/service/CapabilityService.java
@@ -45,7 +45,7 @@ public class CapabilityService extends KogitoService {
     public void addCapabilityToUser(String capability, String capabilityString) {
         log.info(LOG_PREPEND + "Updating user capability: " + capability + " = " + capabilityString);
         CapabilityNode[] capabilityNodes = CommonUtils.getArrayFromString(capabilityString, CapabilityNode.class, CapabilityNode::parseNode);
-        capabilities.addCapabilityToBaseEntity(userToken.getProductCode(), userToken.getCode(), capability, capabilityNodes);
+        capabilities.addCapabilityToBaseEntity(userToken.getProductCode(), userToken.getUserCode(), capability, capabilityNodes);
     }
 
     /**

--- a/qwandaq/src/main/java/life/genny/qwandaq/models/GennyToken.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/models/GennyToken.java
@@ -275,8 +275,10 @@ public class GennyToken implements Serializable {
 	}
 
 	/**
+	 * @deprecated use {@link GennyToken#getUserCode} for base entity code instead
 	 * @return String
 	 */
+	@Deprecated
 	public String getCode() {
 		return code;
 	}

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/BaseEntityUtils.java
@@ -269,6 +269,7 @@ public class BaseEntityUtils {
 	public BaseEntity getBaseEntityFromLinkAttribute(BaseEntity baseEntity, String attributeCode, boolean bundleAttributes) {
 		String value = getStringValueOfAttribute(baseEntity, attributeCode);
 		if (StringUtils.isBlank(value)) {
+			log.error("Value contained within " + baseEntity.getCode() + ":" + attributeCode + " is null. Cannot retrieve base entity from lnk attribute");
 			return null;
 		}
 		String newBaseEntityCode = CommonUtils.cleanUpAttributeValue(value);


### PR DESCRIPTION
GennyToken.getCode is null in all cases that I have used it (where there has been a valid session), and it has been mistaken for GennyToken.getUserCode way too many times.

Also added extra error logging on null return