### PR TITLE
Preemptively stopping array index out of bounds exception

### DIFF
--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
@@ -346,7 +346,7 @@ public class CapabilitiesManager extends Manager {
 				// Map data to capability. If capability name/tag is missing then use the code
 				// with standard capitalisation
 				.map((String[] item) -> createCapability(productCode, item[0],
-						(item.length == 2 && item[1] != null ? item[1] : CommonUtils.normalizeString(item[0]))))
+						(item.length == 2 && item[1] != null ? item[1] : CommonUtils.normalizeString(item[0]) + " Capability")))
 				// add each capability attribute to the capability map, stripping the CAP_
 				// prefix to be used with the constants
 				.forEach((Attribute attr) -> capabilityMap.put(attr.getCode(), attr));

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
@@ -15,6 +15,8 @@ import life.genny.qwandaq.Question;
 import life.genny.qwandaq.QuestionQuestion;
 import life.genny.qwandaq.intf.ICapabilityFilterable;
 import life.genny.qwandaq.utils.*;
+
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import life.genny.qwandaq.attribute.Attribute;
@@ -346,7 +348,7 @@ public class CapabilitiesManager extends Manager {
 				// Map data to capability. If capability name/tag is missing then use the code
 				// with standard capitalisation
 				.map((String[] item) -> createCapability(productCode, item[0],
-						(item.length == 2 && item[1] != null ? item[1] : CommonUtils.normalizeString(item[0]) + " Capability")))
+						(item.length == 2 && !StringUtils.isBlank(item[1]) ? item[1] : CommonUtils.normalizeString(item[0]) + " Capability")))
 				// add each capability attribute to the capability map, stripping the CAP_
 				// prefix to be used with the constants
 				.forEach((Attribute attr) -> capabilityMap.put(attr.getCode(), attr));

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/CapabilitiesManager.java
@@ -346,7 +346,7 @@ public class CapabilitiesManager extends Manager {
 				// Map data to capability. If capability name/tag is missing then use the code
 				// with standard capitalisation
 				.map((String[] item) -> createCapability(productCode, item[0],
-						(item[1] != null ? item[1] : CommonUtils.normalizeString(item[0]))))
+						(item.length == 2 && item[1] != null ? item[1] : CommonUtils.normalizeString(item[0]))))
 				// add each capability attribute to the capability map, stripping the CAP_
 				// prefix to be used with the constants
 				.forEach((Attribute attr) -> capabilityMap.put(attr.getCode(), attr));


### PR DESCRIPTION
This will be necessary as the whole point of line 349 was to allow entries in the capability attribute map to be single entry, to make them less verbose. This is partially implemented and this fix allows for that