### PR TITLE
Dropkick Target Fix

### DIFF
--- a/dropkick/src/main/java/life/genny/dropkick/live/data/InternalConsumer.java
+++ b/dropkick/src/main/java/life/genny/dropkick/live/data/InternalConsumer.java
@@ -137,17 +137,17 @@ public class InternalConsumer {
 		List<BaseEntity> definitions = new ArrayList<>();
 		BaseEntity definition = null; // For wip usage
     
-    target = beUtils.getBaseEntity(targetCode);
-    // TODO: This will break if it is an old target without a processId
-    BaseEntity def = defUtils.getDEF(target);
-    definitions.add(def);
-
 		if (!StringUtils.isBlank(processId)) {
 			ProcessData processData = qwandaUtils.fetchProcessData(processId);
 			if (processData == null) {
 				log.error("Process data not found for processId: " + processId);
 				return;
 			}
+      target = beUtils.getBaseEntity(processData.getTargetCode());
+      // TODO: This will break if it is an old target without a processId
+      BaseEntity def = defUtils.getDEF(target);
+      definitions.add(def);
+
 			BaseEntity processEntity = qwandaUtils.generateProcessEntity(processData);
       // update transient target with process enity information
       log.debug("Adding processentity attributes to target");
@@ -163,6 +163,11 @@ public class InternalConsumer {
 				BaseEntity processDef = beUtils.getBaseEntity(defCode, true);
 				definitions.add(processDef);
 			}
+    } else {
+      target = beUtils.getBaseEntity(targetCode);
+      // TODO: This will break if it is an old target without a processId
+      BaseEntity def = defUtils.getDEF(target);
+      definitions.add(def);
     }
 
 		Optional<EntityAttribute> searchEA = Optional.empty();

--- a/dropkick/src/main/java/life/genny/dropkick/live/data/InternalConsumer.java
+++ b/dropkick/src/main/java/life/genny/dropkick/live/data/InternalConsumer.java
@@ -152,7 +152,7 @@ public class InternalConsumer {
       // update transient target with process enity information
       log.debug("Adding processentity attributes to target");
       for (EntityAttribute ea : processEntity.getBaseEntityAttributes()) {
-        EntityAttribute copy = ea;
+        EntityAttribute copy = ea.clone();
         copy.setBaseEntityCode(target.getCode());
         target.addAttribute(copy);
       }

--- a/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
+++ b/kogitoq/gadaq/src/main/resources/life/genny/gadaq/Edit.bpmn2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_ZQxucIJlEDuAv4EBWwixbg" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_nLcJkL8NEDuhK8EYCpeR_A" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_questionCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_sourceCodeItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_targetCodeItem" structureRef="String"/>
@@ -10,6 +10,11 @@
   <bpmn2:itemDefinition id="_currentPcmItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_numPagesItem" structureRef="Integer"/>
   <bpmn2:itemDefinition id="_taskExchangeItem" structureRef="life.genny.kogito.common.models.TaskExchange"/>
+  <bpmn2:itemDefinition id="_parentItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_locationItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_pcmCodeItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_InMessageType"/>
+  <bpmn2:itemDefinition id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_OutMessageType"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__9D02C26B-B836-4E7D-8898-B32157CC6F5B_pcmCodesOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_buttonEventsInputXItem" structureRef="String"/>
@@ -19,20 +24,39 @@
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_targetCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_sourceCodeInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A_taskExchangeOutputXItem" structureRef="life.genny.kogito.common.models.TaskExchange"/>
+  <bpmn2:itemDefinition id="_5999CB97-2BE8-4093-A097-498AD19E202B_InMessageType"/>
+  <bpmn2:itemDefinition id="_5999CB97-2BE8-4093-A097-498AD19E202B_OutMessageType"/>
   <bpmn2:itemDefinition id="__5999CB97-2BE8-4093-A097-498AD19E202B_pcmCodesInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__5999CB97-2BE8-4093-A097-498AD19E202B_currentIndexInputXItem" structureRef="Integer"/>
   <bpmn2:itemDefinition id="__5999CB97-2BE8-4093-A097-498AD19E202B_currentPcmOutputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_InMessageType"/>
+  <bpmn2:itemDefinition id="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_OutMessageType"/>
+  <bpmn2:message id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_InMessage" itemRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_InMessageType"/>
+  <bpmn2:message id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_OutMessage" itemRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_OutMessageType"/>
   <bpmn2:interface id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceInterface" name="life.genny.kogito.common.service.EditService" implementationRef="life.genny.kogito.common.service.EditService">
-    <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="getEditPcmCodes" implementationRef="getEditPcmCodes"/>
+    <bpmn2:operation id="_9D02C26B-B836-4E7D-8898-B32157CC6F5B_ServiceOperation" name="getEditPcmCodes" implementationRef="getEditPcmCodes">
+      <bpmn2:inMessageRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_InMessage</bpmn2:inMessageRef>
+      <bpmn2:outMessageRef>_9D02C26B-B836-4E7D-8898-B32157CC6F5B_OutMessage</bpmn2:outMessageRef>
+    </bpmn2:operation>
   </bpmn2:interface>
+  <bpmn2:message id="_5999CB97-2BE8-4093-A097-498AD19E202B_InMessage" itemRef="_5999CB97-2BE8-4093-A097-498AD19E202B_InMessageType"/>
+  <bpmn2:message id="_5999CB97-2BE8-4093-A097-498AD19E202B_OutMessage" itemRef="_5999CB97-2BE8-4093-A097-498AD19E202B_OutMessageType"/>
   <bpmn2:interface id="_5999CB97-2BE8-4093-A097-498AD19E202B_ServiceInterface" name="life.genny.kogito.common.service.EditService" implementationRef="life.genny.kogito.common.service.EditService">
-    <bpmn2:operation id="_5999CB97-2BE8-4093-A097-498AD19E202B_ServiceOperation" name="getCurrentPcm" implementationRef="getCurrentPcm"/>
+    <bpmn2:operation id="_5999CB97-2BE8-4093-A097-498AD19E202B_ServiceOperation" name="getCurrentPcm" implementationRef="getCurrentPcm">
+      <bpmn2:inMessageRef>_5999CB97-2BE8-4093-A097-498AD19E202B_InMessage</bpmn2:inMessageRef>
+      <bpmn2:outMessageRef>_5999CB97-2BE8-4093-A097-498AD19E202B_OutMessage</bpmn2:outMessageRef>
+    </bpmn2:operation>
   </bpmn2:interface>
+  <bpmn2:message id="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_InMessage" itemRef="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_InMessageType"/>
+  <bpmn2:message id="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_OutMessage" itemRef="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_OutMessageType"/>
   <bpmn2:interface id="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_ServiceInterface" name="life.genny.kogito.common.service.NavigationService" implementationRef="life.genny.kogito.common.service.NavigationService">
-    <bpmn2:operation id="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_ServiceOperation" name="redirect" implementationRef="redirect"/>
+    <bpmn2:operation id="_3C7C8C09-2277-44DE-8601-70672DE9D0FC_ServiceOperation" name="redirect" implementationRef="redirect">
+      <bpmn2:inMessageRef>_3C7C8C09-2277-44DE-8601-70672DE9D0FC_InMessage</bpmn2:inMessageRef>
+      <bpmn2:outMessageRef>_3C7C8C09-2277-44DE-8601-70672DE9D0FC_OutMessage</bpmn2:outMessageRef>
+    </bpmn2:operation>
   </bpmn2:interface>
-  <bpmn2:collaboration id="_B49C7670-6F61-4DFE-8E3B-ED2413242BF4" name="Default Collaboration">
-    <bpmn2:participant id="_5C15B47E-FB24-4B51-9DC9-A3CBE448BDDB" name="Pool Participant" processRef="edit"/>
+  <bpmn2:collaboration id="_42B4556F-2B24-4243-91F4-0397671CB126" name="Default Collaboration">
+    <bpmn2:participant id="_743853D2-5185-4916-B290-35FB90E69BD3" name="Pool Participant" processRef="edit"/>
   </bpmn2:collaboration>
   <bpmn2:process id="edit" drools:packageName="life.genny.gadaq" drools:version="1.0" drools:adHoc="false" name="Edit" isExecutable="true" processType="Public">
     <bpmn2:documentation><![CDATA[Edit an Item]]></bpmn2:documentation>
@@ -46,19 +70,22 @@
     <bpmn2:property id="currentPcm" itemSubjectRef="_currentPcmItem" name="currentPcm"/>
     <bpmn2:property id="numPages" itemSubjectRef="_numPagesItem" name="numPages"/>
     <bpmn2:property id="taskExchange" itemSubjectRef="_taskExchangeItem" name="taskExchange"/>
+    <bpmn2:property id="parent" itemSubjectRef="_parentItem" name="parent"/>
+    <bpmn2:property id="location" itemSubjectRef="_locationItem" name="location"/>
+    <bpmn2:property id="pcmCode" itemSubjectRef="_pcmCodeItem" name="pcmCode"/>
     <bpmn2:sequenceFlow id="_79D029B8-EDC6-4907-B552-22B4D8382BFA" sourceRef="_B2952C73-6734-47B0-BBB3-846BB771C0EB" targetRef="_221EE1F5-73BA-4EEF-A54B-AE4223A5BAFF"/>
     <bpmn2:sequenceFlow id="_1CAC669E-A31B-4EE4-AAF7-4632BB3A9A04" sourceRef="_49A1ECC5-2F04-4A38-9E0B-C4453F69E223" targetRef="_3C7C8C09-2277-44DE-8601-70672DE9D0FC">
       <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return false;]]></bpmn2:conditionExpression>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_E052879F-5B02-4BA2-A996-405333D0F6B2" sourceRef="_718B369D-74D8-44C0-86F9-FBAC4E142B09" targetRef="_221EE1F5-73BA-4EEF-A54B-AE4223A5BAFF"/>
     <bpmn2:sequenceFlow id="_4F23B444-FCFE-4B8E-877D-494FDC15AE28" sourceRef="_221EE1F5-73BA-4EEF-A54B-AE4223A5BAFF" targetRef="_5999CB97-2BE8-4093-A097-498AD19E202B"/>
+    <bpmn2:sequenceFlow id="_08B246BF-4C44-4F5B-8461-34D7AE490D9F" sourceRef="_36C272A6-1534-42A3-97F4-1AA2F118809C" targetRef="_49A1ECC5-2F04-4A38-9E0B-C4453F69E223">
+      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return (taskExchange.isSubmit() && currentIndex >= (numPages - 1)) || taskExchange.isCancel();]]></bpmn2:conditionExpression>
+    </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_3FD8B47D-E441-4370-87B9-8777054E9BE9" sourceRef="_36C272A6-1534-42A3-97F4-1AA2F118809C" targetRef="_B2952C73-6734-47B0-BBB3-846BB771C0EB">
       <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return taskExchange.isPrevious() || (
     currentIndex < (numPages - 1) && taskExchange.isSubmit()
 );]]></bpmn2:conditionExpression>
-    </bpmn2:sequenceFlow>
-    <bpmn2:sequenceFlow id="_08B246BF-4C44-4F5B-8461-34D7AE490D9F" sourceRef="_36C272A6-1534-42A3-97F4-1AA2F118809C" targetRef="_49A1ECC5-2F04-4A38-9E0B-C4453F69E223">
-      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression" language="http://www.java.com/java"><![CDATA[return (taskExchange.isSubmit() && currentIndex >= (numPages - 1)) || taskExchange.isCancel();]]></bpmn2:conditionExpression>
     </bpmn2:sequenceFlow>
     <bpmn2:sequenceFlow id="_236B7659-9EB5-4010-9C90-02EE06EA92EE" sourceRef="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" targetRef="_36C272A6-1534-42A3-97F4-1AA2F118809C"/>
     <bpmn2:sequenceFlow id="_EB9FA3CB-9790-4970-8EAD-F8AFC512BB59" sourceRef="_9D02C26B-B836-4E7D-8898-B32157CC6F5B" targetRef="_718B369D-74D8-44C0-86F9-FBAC4E142B09"/>
@@ -194,8 +221,8 @@ kcontext.setVariable("currentIndex", 0);</bpmn2:script>
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:incoming>_236B7659-9EB5-4010-9C90-02EE06EA92EE</bpmn2:incoming>
-      <bpmn2:outgoing>_08B246BF-4C44-4F5B-8461-34D7AE490D9F</bpmn2:outgoing>
       <bpmn2:outgoing>_3FD8B47D-E441-4370-87B9-8777054E9BE9</bpmn2:outgoing>
+      <bpmn2:outgoing>_08B246BF-4C44-4F5B-8461-34D7AE490D9F</bpmn2:outgoing>
     </bpmn2:exclusiveGateway>
     <bpmn2:callActivity id="_6C8828FE-D8C3-4A5F-9947-A80F2C4ADF6A" drools:independent="true" drools:waitForCompletion="true" name="PQ - Edit Current Page" calledElement="processQuestions">
       <bpmn2:extensionElements>
@@ -405,16 +432,16 @@ kcontext.setVariable("buttonEvents", "Cancel,Previous,Next");</bpmn2:script>
         <di:waypoint x="1223.5" y="746.5"/>
         <di:waypoint x="1349" y="747"/>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="edge_shape__36C272A6-1534-42A3-97F4-1AA2F118809C_to_shape__49A1ECC5-2F04-4A38-9E0B-C4453F69E223" bpmnElement="_08B246BF-4C44-4F5B-8461-34D7AE490D9F">
-        <di:waypoint x="1377" y="747"/>
-        <di:waypoint x="1531" y="746"/>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__36C272A6-1534-42A3-97F4-1AA2F118809C_to_shape__B2952C73-6734-47B0-BBB3-846BB771C0EB" bpmnElement="_3FD8B47D-E441-4370-87B9-8777054E9BE9">
         <di:waypoint x="1377" y="747"/>
         <di:waypoint x="1377" y="368.14425244177295"/>
         <di:waypoint x="844" y="368.14425244177295"/>
         <di:waypoint x="844" y="423.99999999999994"/>
         <di:waypoint x="844" y="423.99999999999994"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="edge_shape__36C272A6-1534-42A3-97F4-1AA2F118809C_to_shape__49A1ECC5-2F04-4A38-9E0B-C4453F69E223" bpmnElement="_08B246BF-4C44-4F5B-8461-34D7AE490D9F">
+        <di:waypoint x="1377" y="747"/>
+        <di:waypoint x="1531" y="746"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__221EE1F5-73BA-4EEF-A54B-AE4223A5BAFF_to_shape__5999CB97-2BE8-4093-A097-498AD19E202B" bpmnElement="_4F23B444-FCFE-4B8E-877D-494FDC15AE28">
         <di:waypoint x="844" y="594"/>
@@ -609,7 +636,7 @@ kcontext.setVariable("buttonEvents", "Cancel,Previous,Next");</bpmn2:script>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_ZQxucIJlEDuAv4EBWwixbg</bpmn2:source>
-    <bpmn2:target>_ZQxucIJlEDuAv4EBWwixbg</bpmn2:target>
+    <bpmn2:source>_nLcJkL8NEDuhK8EYCpeR_A</bpmn2:source>
+    <bpmn2:target>_nLcJkL8NEDuhK8EYCpeR_A</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>


### PR DESCRIPTION
This PR contains two seperate updates:

- Update to dropkick to ensure dropdown searches are considering all previous information from the task target.
- Adding three necessary process variables to the Edit.bpmn workflow (`parent`, `location` and `pcmCode`) to prevent this from crashing data-index.