### PR TITLE
10.3.0 consolidated se reqs

### DIFF
--- a/dropkick/src/main/java/life/genny/dropkick/live/data/InternalConsumer.java
+++ b/dropkick/src/main/java/life/genny/dropkick/live/data/InternalConsumer.java
@@ -188,10 +188,12 @@ public class InternalConsumer {
 
 		log.debug("Using Search Entity: " + searchEntity);
 		// Filter by name wildcard provided by user
+		if(!StringUtils.isBlank(searchText)) {
 		searchEntity.add(new Or(
 			new Filter(Attribute.PRI_NAME, Operator.LIKE, searchText + "%"),
 			new Filter(Attribute.PRI_NAME, Operator.LIKE, "% " + searchText + "%")));
-
+		}
+		
 		searchEntity.add(new Column("PRI_NAME", "Name"));
 
 		// init context map

--- a/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
@@ -1,5 +1,6 @@
 package life.genny.fyodor.utils;
 
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -122,11 +123,21 @@ public class CapHandler extends Manager {
 			}
 
 			if(currentClause instanceof Clause clause && clause.hasCapabilityRequirements()) {
-				for(ClauseContainer child : clause.getClauseContainers()) {
-					if(child.getFilter() != null && !child.getFilter().requirementsMet(userCapabilities, requirementsConfig)) {
-						child.setFilter(null);
+				Iterator<ClauseContainer> iter = clause.getClauseContainers().iterator();
+				if(iter.hasNext()) {
+					ClauseContainer child = iter.next();
+					while(iter.hasNext()) {
+						if(child.getFilter() != null && !child.getFilter().requirementsMet(userCapabilities, requirementsConfig)) {
+							iter.remove();
+						}
+						child = iter.next();
 					}
 				}
+				// for(ClauseContainer child : clause.getClauseContainers()) {
+				// 	if(child.getFilter() != null && !child.getFilter().requirementsMet(userCapabilities, requirementsConfig)) {
+				// 		child.setFilter(null);
+				// 	}
+				// }
 			}
 
 			visited.add(currentClause);

--- a/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
@@ -46,7 +46,7 @@ public class CapHandler extends Manager {
 		if (hasSecureToken(userToken))
 			return;
 		
-		if(!searchEntity.hasRequirements()) {
+		if(!searchEntity.hasCapabilityRequirements()) {
 			log.debug("no requirements to check for searchEntity: " + searchEntity.getCode() + ". Skipping");
 			return;
 		} else {
@@ -150,14 +150,14 @@ public class CapHandler extends Manager {
 		//  TODO: Get rid of this service code check. Not ideal
 		// TODO: We also need to consolidate what it means to be a service user
 		boolean isService = hasSecureToken(userToken);
-		if(!isService) {
-			log.info("Checking: " + trait);
-			log.info("Requirements: " + CommonUtils.getArrayString(trait.getCapabilityRequirements()));
-			return trait.requirementsMet(userCapabilities, reqConfig);
-		} else {
+		if(isService) {
 			log.info("Service token. Bypassing requirements");
+			return true;
 		}
-		return true;
+
+		log.info("Checking: " + trait);
+		log.info("Requirements: " + CommonUtils.getArrayString(trait.getCapabilityRequirements()));
+		return trait.requirementsMet(userCapabilities, reqConfig);
 	}
 
 	public static boolean hasSecureToken(UserToken userToken) {

--- a/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/CapHandler.java
@@ -145,7 +145,7 @@ public class CapHandler extends Manager {
 	 */
 	public void refineClauseContainersFromCapabilities(SearchEntity searchEntity, CapabilitySet userCapabilities) {
 		List<ClauseContainer> containers = searchEntity.getClauseContainers();
-		log.info("Filtering " + containers.size() + " filters"); 
+		log.info("Filtering " + containers.size() + " clauseContainers"); 
 		for(ClauseContainer container : containers) {
 			filterClauseContainerBFS(container, userCapabilities);
 		}

--- a/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
+++ b/fyodor/src/main/java/life/genny/fyodor/utils/FyodorUltra.java
@@ -338,7 +338,9 @@ public class FyodorUltra {
 		Or or = clauseContainer.getOr();
 
 		Clause clause = (and != null ? and : or);
-
+		if(clause == null) {
+			throw new QueryBuilderException("Invalid ClauseContainer: " + clauseContainer);
+		}
 		// find predicate for each clause argument
 		List<Predicate> predicates = new ArrayList<>();
 		for (ClauseContainer child : clause.getClauseContainers())

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/SearchEntity.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/SearchEntity.java
@@ -94,20 +94,18 @@ public class SearchEntity extends BaseEntity {
 	 * Check whether anything in this search entity has capability requirements
 	 * @return <b>true</b> if there is at least one CapabilityRequirement. <b>false</b> otherwise
 	 */
-	@JsonbTransient
-	public boolean hasRequirements() {
-		// Yucky n2. Will need to modify this later
+	@Override
+	public boolean hasCapabilityRequirements() {
 		for(Map.Entry<Integer, List<? extends Trait>> traitList : traits.entrySet()) {
 			for(Trait t : traitList.getValue()) {
-				if(!t.getCapabilityRequirements().isEmpty())
+				if(t.hasCapabilityRequirements())
 					return true;
 			}
 		}
 
 		for(ClauseContainer c : clauseContainers) {
-			if(c.getFilter() != null) {
-				if(!c.getFilter().getCapabilityRequirements().isEmpty())
-					return true;
+			if(c.hasCapabilityRequirements()) {
+				return true;
 			}
 		}
 

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/clause/Clause.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/clause/Clause.java
@@ -55,4 +55,12 @@ public class Clause implements ClauseArgument {
 		this.clauseContainers = clauseContainers;
 	}
 
+	public boolean hasCapabilityRequirements() {
+		for(ClauseContainer c : clauseContainers) {
+			if(c.hasCapabilityRequirements())
+				return true;
+		}
+		return false;
+	}
+
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/clause/ClauseContainer.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/clause/ClauseContainer.java
@@ -66,4 +66,18 @@ public class ClauseContainer {
       return true;
     return false;
   }
+
+  public String toString() {
+    return new StringBuilder("ClauseContainer: [")
+    .append("requirements: ")
+    .append(hasCapabilityRequirements())
+    .append(", and: ")
+    .append(and != null ? and : "null")
+    .append(", or: ")
+    .append(or != null ? or : "null")
+    .append(", filter: ")
+    .append(filter != null ? filter.getCode() : "null")
+    .append("]")
+    .toString();
+  }
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/entity/search/clause/ClauseContainer.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/entity/search/clause/ClauseContainer.java
@@ -54,6 +54,16 @@ public class ClauseContainer {
   }
 
   public boolean requirementsMet(CapabilitySet userCapabilities) {
-    return filter.requirementsMet(userCapabilities);
+    return filter != null && filter.requirementsMet(userCapabilities);
+  }
+
+  public boolean hasCapabilityRequirements() {
+    if(filter != null && filter.hasCapabilityRequirements())
+      return true;
+    if(and != null && and.hasCapabilityRequirements())
+      return true;
+    if(or != null && or.hasCapabilityRequirements())
+      return true;
+    return false;
   }
 }

--- a/qwandaq/src/main/java/life/genny/qwandaq/intf/ICapabilityFilterable.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/intf/ICapabilityFilterable.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.json.bind.annotation.JsonbTransient;
+
 import org.jboss.logging.Logger;
 
 import life.genny.qwandaq.datatype.capability.core.Capability;
@@ -23,6 +25,11 @@ public interface ICapabilityFilterable {
     }
     
     public Set<Capability> getCapabilityRequirements();
+
+    @JsonbTransient
+    public default boolean hasCapabilityRequirements() {
+        return getCapabilityRequirements() != null && !getCapabilityRequirements().isEmpty();
+    }
 
     public default void setCapabilityRequirements(Capability... requirements) {
         setCapabilityRequirements(new HashSet<>(Arrays.asList(requirements)));

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleDropdownBuilder.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleDropdownBuilder.java
@@ -1,0 +1,50 @@
+package life.genny.qwandaq.managers.capabilities.role;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import life.genny.qwandaq.attribute.Attribute;
+import life.genny.qwandaq.datatype.capability.core.Capability;
+import life.genny.qwandaq.entity.Definition;
+import life.genny.qwandaq.entity.search.SearchEntity;
+import life.genny.qwandaq.entity.search.clause.Or;
+import life.genny.qwandaq.entity.search.trait.Filter;
+import life.genny.qwandaq.entity.search.trait.Operator;
+import life.genny.qwandaq.entity.search.trait.Trait;
+
+
+public class RoleDropdownBuilder {
+    private static final String SBE_SER_LNK_ROLE = "SBE_SER_LNK_ROLE";
+    
+    private String name;
+
+    private final List<Filter> filters = new ArrayList<>();
+
+    public RoleDropdownBuilder(String name) {
+        this.name = name;
+    }
+
+    public RoleDropdownBuilder addRole(String roleCode, Capability... requirements) {
+        roleCode = RoleManager.cleanRoleCode(roleCode);
+        Filter f = new Filter(Attribute.PRI_CODE, Operator.EQUALS, roleCode);
+        if(requirements == null || requirements.length == 0) {
+            filters.add(f);
+            return this;
+        }
+
+        Trait.Decorator<Filter> decorator = Trait.decorator(f);
+        for(Capability cap : requirements) {
+            decorator.addCapabilityRequirement(cap);
+        }
+
+        filters.add(decorator.build());
+        return this;
+
+    }
+
+    public SearchEntity build() {
+        return new SearchEntity(SBE_SER_LNK_ROLE, name)
+            .add(new Filter(Attribute.LNK_DEF, Operator.CONTAINS, Definition.DEF_ROLE))
+            .add(new Or(filters.toArray(new Filter[0])));
+    }
+}

--- a/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/managers/capabilities/role/RoleManager.java
@@ -356,7 +356,7 @@ public class RoleManager extends Manager {
 	public static String cleanRoleCode(final String rawRoleCode) {
 		String cleanRoleCode = rawRoleCode.toUpperCase();
 		if (!cleanRoleCode.startsWith(Prefix.ROL_)) {
-			cleanRoleCode = Prefix.ROL_ + cleanRoleCode;
+			cleanRoleCode = Prefix.ROL_.concat(cleanRoleCode);
 		}
 
 		return cleanRoleCode;

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/EntityAttributeUtils.java
@@ -6,7 +6,6 @@ import life.genny.qwandaq.constants.GennyConstants;
 import life.genny.qwandaq.datatype.DataType;
 import life.genny.qwandaq.entity.BaseEntity;
 import life.genny.qwandaq.entity.Definition;
-import life.genny.qwandaq.entity.PCM;
 import life.genny.qwandaq.exception.runtime.ItemNotFoundException;
 import life.genny.qwandaq.managers.CacheManager;
 import life.genny.qwandaq.serialization.baseentity.BaseEntityKey;

--- a/qwandaq/src/main/java/life/genny/qwandaq/utils/product/SearchBuilder.java
+++ b/qwandaq/src/main/java/life/genny/qwandaq/utils/product/SearchBuilder.java
@@ -10,11 +10,10 @@ import com.oracle.svm.core.annotate.Inject;
 import life.genny.qwandaq.attribute.Attribute;
 import life.genny.qwandaq.constants.Prefix;
 import life.genny.qwandaq.entity.search.SearchEntity;
-import life.genny.qwandaq.entity.search.clause.Or;
 import life.genny.qwandaq.entity.search.trait.Filter;
 import life.genny.qwandaq.entity.search.trait.Operator;
 import life.genny.qwandaq.managers.CacheManager;
-
+import life.genny.qwandaq.managers.capabilities.role.RoleDropdownBuilder;
 import life.genny.qwandaq.entity.BaseEntity;
 import life.genny.qwandaq.entity.Definition;
 
@@ -25,7 +24,6 @@ import life.genny.qwandaq.entity.Definition;
  */
 @ApplicationScoped
 public class SearchBuilder {
-    private static final String SBE_SER_LNK_ROLE = "SBE_SER_LNK_ROLE";
 
     @Inject
     Logger log;
@@ -101,15 +99,8 @@ public class SearchBuilder {
      * @param filters - filters to apply to get the base entities to return from the dropdown SearchEntity
      * @return a role SearchEntity with the filters set to find the matching roles
      */
-    public SearchEntity roleDropdown(String dropdownName, String... roleCodes) {
-        Filter[] filters = new Filter[roleCodes.length];
-        for(int i = 0; i < roleCodes.length; i++) {
-            filters[i] = new Filter(Attribute.PRI_CODE, Operator.EQUALS, roleCodes[i]);
-        }
-        
-        return new SearchEntity(SBE_SER_LNK_ROLE, dropdownName)
-            .add(new Filter(Attribute.LNK_DEF, Operator.CONTAINS, Definition.DEF_ROLE))
-            .add(new Or(filters));
+    public RoleDropdownBuilder roleDropdown(String dropdownName) {
+        return new RoleDropdownBuilder(dropdownName);
     }
 
     /**


### PR DESCRIPTION
Tested on dev with the use case
Implemented BFS to navigate the clause container tree for a SearchEntity and pick out the filters that the user doesn't meet the capability requirements for

Removed the PRI_NAME filter if the searchText supplied by the user is blank (if this is a mistake please request changes for it)