### PR TITLE
Logging envs

### DIFF
--- a/serviceq/src/main/resources/application.properties
+++ b/serviceq/src/main/resources/application.properties
@@ -287,11 +287,11 @@ kogito.jobs-service.url=http://alyson.genny.life:8581
 quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss.SSSZZ} %-5p [%c{15.}] (%L) %s%e%n
 
-quarkus.log.level=${LOG_LEVEL:INFO}
+quarkus.log.level=${QUARKUS_LOG_LEVEL:INFO}
 quarkus.log.console.color=true
 
 quarkus.log.category."io.quarkus".level=INFO
-quarkus.log.category."life.genny".level=DEBUG
+quarkus.log.category."life.genny".level=${GENNY_LOG_LEVE:TRACE}
 quarkus.log.category."org.apache.kafka".level=ERROR
 quarkus.log.category."org.apache.kafka.clients.consumer.ConsumerConfig".level=ERROR
 quarkus.log.category."org.apache.kafka.clients.producer.ProducerConfig".level=ERROR

--- a/serviceq/src/main/resources/application.properties
+++ b/serviceq/src/main/resources/application.properties
@@ -291,7 +291,7 @@ quarkus.log.level=${QUARKUS_LOG_LEVEL:INFO}
 quarkus.log.console.color=true
 
 quarkus.log.category."io.quarkus".level=INFO
-quarkus.log.category."life.genny".level=${GENNY_LOG_LEVE:TRACE}
+quarkus.log.category."life.genny".level=${GENNY_LOG_LEVEL:TRACE}
 quarkus.log.category."org.apache.kafka".level=ERROR
 quarkus.log.category."org.apache.kafka.clients.consumer.ConsumerConfig".level=ERROR
 quarkus.log.category."org.apache.kafka.clients.producer.ProducerConfig".level=ERROR


### PR DESCRIPTION
Instead of having one `LOG_LEVEL` env that controls the quarkus logging level and hardcoding our log level for logs relating to `life.genny` we can have env: `QUARKUS_LOG_LEVEL` for quarkus logging and `GENNY_LOG_LEVEL` for `life.genny` logging, so we can choose what level of logging we want the genny logs to output.

Further on the servers the old (verbose) logging script that got lost has been found that allows to pick which logging levels to filter from the logging provided in the container, and can be passed on to devops for permanent storage in the scripts repo